### PR TITLE
Removed componentDidUnmount

### DIFF
--- a/react.md
+++ b/react.md
@@ -48,7 +48,6 @@ layout: default
 
     componentDidMount
     componentDidUpdate
-    componentDidUnmount
 
 
 ### Initial states


### PR DESCRIPTION
This method does not exist. At this point in time the component is deleted, so you have to use componentWillUnmount instead.