### PR TITLE
Stylus color operator correction

### DIFF
--- a/stylus.md
+++ b/stylus.md
@@ -56,8 +56,8 @@ Multiple args:
 
 ### Color operators
 
-    #888 + 50%    // => #c3c3c3 (darken)
-    #888 - 50%    // => #444 (lighten)
+    #888 + 50%    // => #c3c3c3 (lighten)
+    #888 - 50%    // => #444 (darken)
     #f00 + 50deg  // => #ffd500 (hue)
 
 ### Casting


### PR DESCRIPTION
The Stylus color operators are actually opposite of what you have in here. Subtracting a percentage makes the color darker, and adding a percentage makes the color lighter. You had it backwards :)
https://learnboost.github.io/stylus/docs/operators.html#color-operations
