### PR TITLE
Use user_url instead of user_path in last case

### DIFF
--- a/phoenix-routing.md
+++ b/phoenix-routing.md
@@ -46,7 +46,7 @@ user_path(Endpoint, :show, 17)              #=> /users/17
 user_path(Endpoint, :show, %User{id: 17})   #=> /users/17
 user_path(Endpoint, :show, 17, admin: true) #=> /users/17?admin=true
 
-user_path(Endpoint, :index) #=> "http://localhost:4000/users"
+user_url(Endpoint, :index) #=> "http://localhost:4000/users"
 ```
 
 ```elixir


### PR DESCRIPTION
2 identical function call would return different output in 
```
user_path(Endpoint, :index)                 #=> /users
...
user_path(Endpoint, :index) #=> "http://localhost:4000/users"
```
but in fact the last one should use user_url as indicated in doc http://www.phoenixframework.org/docs/routing