### PR TITLE
Comma blames from parent commit

### DIFF
--- a/tig.md
+++ b/tig.md
@@ -84,3 +84,8 @@ You can substitute `git log` → `tig`.
 
 | `i` | Change sort header |
 {: .-shortcuts}
+
+### `h` - Blame view
+
+| `,` | Parent commit |
+{: .-shortcuts}


### PR DESCRIPTION
This is useful for navigating the history of a single line with `,` and `<`.