### PR TITLE
python: correct to 'import re'

### DIFF
--- a/python.md
+++ b/python.md
@@ -76,7 +76,7 @@ title: Python
 
 ### Regex
 
-    import regex
+    import re
 
     re.match(r'^[aeiou]', str)
     re.sub(r'^[aeiou]', '?', str)


### PR DESCRIPTION
Typo: `import regex` to `import re`

[Python 2.7](https://docs.python.org/2/library/re.html)
[Python 3+](https://docs.python.org/3.6/library/re.html)