### PR TITLE
Contains not a function, update to includes

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -67,7 +67,7 @@ See: [Binary and octal literals](http://babeljs.io/docs/learn-es2015/#binary-and
 
 ```js
 "hello".repeat(3)
-"hello".contains("ll")
+"hello".includes("ll")
 "\u1E9B\u0323".normalize("NFC")
 ```
 


### PR DESCRIPTION
Not aware of String.prototype.contains becoming an ES standard, however, String.prototype.includes is functionally equivalent. 

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes