### PR TITLE
Fix typo

### DIFF
--- a/react.md
+++ b/react.md
@@ -204,7 +204,7 @@ this.state
 this.props
 ```
 
-These methods and properies are available for `Component` instances.
+These methods and properties are available for `Component` instances.
 
 See: [Component API](http://facebook.github.io/react/docs/component-api.html)
 


### PR DESCRIPTION
Fixes typo from 'properies' to 'properties'