### PR TITLE
Elixir: Fix Enum example and rename "char list" to "charlist"

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -59,7 +59,7 @@ users = [ "Tom", "Dick", "Harry" ]
 {: data-line="1"}
 
 ```elixir
-Enum.map(user, fn user ->
+Enum.map(users, fn user ->
   IO.puts "Hello " <> user
 end)
 ```
@@ -155,7 +155,7 @@ end
 | `23`                    | Integer         |
 | `3.14`                  | Float           |
 | ---                     | ---             |
-| `'hello'`               | Char list       |
+| `'hello'`               | Charlist        |
 | `<<2, 3>>`              | Binary          |
 | `"hello"`               | Binary string   |
 | `:hello`                | Atom            |
@@ -308,7 +308,7 @@ n = 12
 
 ```elixir
 n |> digits()         # → [1, 2]
-n |> to_char_list()   # → '12'
+n |> to_charlist()    # → '12'
 n |> to_string()      # → "12"
 n |> is_even()
 n |> is_odd()
@@ -317,7 +317,7 @@ n |> is_odd()
 ```elixir
 # Different base:
 n |> digits(2)        # → [1, 1, 0, 0]
-n |> to_char_list(2)  # → '1100'
+n |> to_charlist(2)   # → '1100'
 n |> to_string(2)     # → "1100"
 ```
 
@@ -676,7 +676,7 @@ exp = ~r/hello/i
 ~w(list of strings)
 ~s[strings with #{interpolation} and \x20 escape codes]
 ~S[no interpolation and no escapes]
-~c(char list)
+~c(charlist)
 ```
 
 Allowed chars: `/` `|` `"` `'` `(` `[` `{` `<` `"""`.


### PR DESCRIPTION
The charlist change is needed because all Elixir core is using the
"charlist" version. We also should use to keep consistency.

Also, to_char_list/1 is deprecated since Elixir 1.5.

References:
- https://github.com/elixir-lang/elixir/blob/ed98604dc3ce7e9a0b057350b13a6de25a71557a/lib/elixir/pages/Deprecations.md#table-of-deprecations
- https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html