### PR TITLE
Fixed destructuring example value

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -212,7 +212,7 @@ var [math = 50, sci = 50, arts = 50] = scores
 
 ```js
 // Result:
-// math === 22, sci === 23, arts === 50
+// math === 22, sci === 33, arts === 50
 ```
 
 Default values can be assigned while destructuring arrays or objects.


### PR DESCRIPTION
```
var scores = [22, 33]
var [math = 50, sci = 50, arts = 50] = scores
```
In the end, sci is equal to 33 (and not 23) :)