### PR TITLE
Change elsif to elif

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -80,7 +80,7 @@ See: [Functions](#functions)
 ```bash
 if [ -z "$string" ]; then
   echo "String is empty"
-elsif [ -n "$string" ]; then
+elif [ -n "$string" ]; then
   echo "String is not empty"
 fi
 ```


### PR DESCRIPTION
Fix a small error in the *Conditionals* section of the **Bash Cheatsheet**.
The Bash syntax allows for `elif` while the cheatsheet uses `elsif`.

Great job by the way! 