### PR TITLE
New: vimdiff

### DIFF
--- a/vim-diff.md
+++ b/vim-diff.md
@@ -1,0 +1,61 @@
+---
+title: Vimdiff
+category: Vim
+layout: 2017/sheet
+tags: [Featured]
+updated: 2017-08-26
+weight: -10
+intro: |
+  [Vim](http://www.vim.org/) is a very efficient text editor. This reference was made for Vim 8.0.
+---
+
+Getting started
+---------------
+{: .-three-column}
+
+### Navigating
+{: .-prime}
+
+| Shortcut       | Description                      |
+| ---            | ---                              |
+| `]c`           | Next difference                  |
+| `[c`           | Previous difference              |
+{: .-shortcuts}
+
+### Editing
+
+| Shortcut | Description                         |
+| ---            | ---                              |
+| `do`           | Diff Obtain! <br>Pull the changes to the current file. |
+| `dp`           | Diff Put! <br>Push the changes to the other file. |
+| ---            | ---                              |
+| `:diffupdate`  | Re-scan the files for differences.                    |
+| `ZQ`           | Quit without checking changes    |
+{: .-shortcuts}
+
+### Folds
+
+| Shortcut      | Description                  |
+| ---           | ---                          |
+| `zo` _/_ `zO` | Open                         |
+| `zc` _/_ `zC` | Close                        |
+| `za` _/_ `zA` | Toggle                       |
+| ---           | ---                          |
+| `zv`          | Open folds for this line     |
+| ---           | ---                          |
+| `zM`          | Close all                    |
+| `zR`          | Open all                     |
+| ---           | ---                          |
+| `zm`          | Fold more _(foldlevel += 1)_ |
+| `zr`          | Fold less _(foldlevel -= 1)_ |
+| ---           | ---                          |
+| `zx`          | Update folds                 |
+{: .-shortcuts}
+
+
+Also see
+--------
+
+- [Vim cheatsheet](https://vim.rtorr.com/) _(vim.rotrr.com)_
+- [Vim documentation](http://vimdoc.sourceforge.net/htmldoc/) _(vimdoc.sourceforge.net)_
+- [Interactive Vim tutorial](http://openvim.com/) _(openvim.com)_


### PR DESCRIPTION
This is a good beginning of a cheatsheet for [`vimdiff`](http://vimdoc.sourceforge.net/htmldoc/diff.html). 

**Note:** vim's -d flag loads vim in diffmode, which basically called vimdiff.

> The easiest way to start editing in diff mode is with the "vimdiff" command. This starts Vim as usual, and additionally sets up for viewing the differences between the arguments.
>
> ```shell
> vimdiff file1 file2 [file3 [file4]]
> ```
>
> This is equivalent to:
>
> ```shell
> vim -d file1 file2 [file3 [file4]]
> ```
