### PR TITLE
ES6: Use for..of in destructuring with loop example

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -250,7 +250,7 @@ This example assigns `x` to the value of the `left` key.
 ### Loops
 
 ```js
-for (let {title, artist} in songs) {
+for (let {title, artist} of songs) {
   ···
 }
 ```


### PR DESCRIPTION
Credits for spotting the error: [this comment](https://devhints.io/es6#comment-3599862808) on the cheatsheet page.