### PR TITLE
Vim guide - minor wording change

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -290,7 +290,7 @@ Uppercase ones are recursive (eg, `zO` is open recursively).
 | `guu`    | lowercase current line (also `gugu`) |
 {: .-shortcuts}
 
-Do these in visual mode.
+Do these in visual or normal mode.
 
 ### Marks
 


### PR DESCRIPTION
Original document alluded to the fact that cases can only be changed from `visual` mode. They also work in `normal` mode.