### PR TITLE
Add Case control flow structure in elixir docs

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -105,7 +105,6 @@ Pattern matching works in function parameters too.
 
 Control flow
 ------------
-{: .-three-column}
 
 ### If
 
@@ -114,6 +113,18 @@ if false do
   "This will never be seen"
 else
   "This will"
+end
+```
+### Case
+
+```elixir
+case {1, 2, 3} do
+  {4, 5, 6} ->
+    "This clause won't match"
+  {1, x, 3} ->
+    "This clause will match and bind x to 2 in this clause"
+  _ ->
+   "This clause would match any value"
 end
 ```
 

--- a/elixir.md
+++ b/elixir.md
@@ -477,7 +477,7 @@ list |> any?()        # → true
 ```
 
 ```elixir
-list |> concat([:d])  # → [:d]
+list |> concat([:d])  # → [:a, :b, :c, :d]
 ```
 
 Also, consider streams instead.


### PR DESCRIPTION
The case condition was missing in the elixir documentation.

I remove the 3 column distribution and now looks like this

![screen shot 2018-01-03 at 21 53 56](https://user-images.githubusercontent.com/1875350/34546231-4301c590-f0d1-11e7-943d-98beb2cbc085.png)
