### PR TITLE
Fix spelling of referer

### DIFF
--- a/phoenix-conn.md
+++ b/phoenix-conn.md
@@ -26,7 +26,7 @@ conn.req_headers   # → [{"content-type", "text/plain"}]
 ```
 
 ```elixir
-conn |> get_req_header("referrer")
+conn |> get_req_header("referer")
 ```
 
 ### Updating conn


### PR DESCRIPTION
Even though it is, in itself, a misspelling! https://en.wikipedia.org/wiki/HTTP_referer