### PR TITLE
es6: simplify example of old array concatenation

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -302,8 +302,7 @@ const users = [
 
 ```js
 const users = admins
-  .concat(editors)
-  .concat([ 'rstacruz' ])
+  .concat(editors, 'rstacruz')
 ```
 
 The spread operator lets you build new arrays in the same way.


### PR DESCRIPTION
`Array.prototype.concat()` can accept several arguments including non-array values.