### PR TITLE
[react] [docs] make React.Fragment example more clear

### DIFF
--- a/react.md
+++ b/react.md
@@ -106,7 +106,7 @@ class Info extends React.Component {
   }
 }
 ```
-As of React v16.2.0 components can return multiple grouped elements without adding extra nodes to the DOM. In this example, you would get the nested components' nodes without a wrapping element.
+As of React v16.2.0, fragments can be used to return multiple children without adding extra wrapping nodes to the DOM.
 
 ```jsx
 class Info extends React.Component {

--- a/react.md
+++ b/react.md
@@ -426,7 +426,8 @@ New features
 
 You can return multiple elements as arrays or fragments.
 
-**Arrays**
+#### Arrays
+
 ```js
 render () {
   // Don't forget the keys!
@@ -438,7 +439,7 @@ render () {
 ```
 {: data-line="3,4,5,6"}
 
-**Fragments**
+#### Fragments
 ```js
 render () {
   // Fragments don't require keys!

--- a/react.md
+++ b/react.md
@@ -106,18 +106,19 @@ class Info extends React.Component {
   }
 }
 ```
-As of React v16.2.0
-
+As of React v16.2.0 components can return multiple grouped elements without adding extra nodes to the DOM. In this example, you would get the nested components' nodes without a wrapping element.
 
 ```jsx
 class Info extends React.Component {
   render () {
     const { avatar, username } = this.props
 
-    return <React.Fragment>
-      <UserAvatar src={avatar} />
-      <UserProfile username={username} />
-    </React.Fragment>
+    return (
+      <React.Fragment>
+        <UserAvatar src={avatar} />
+        <UserProfile username={username} />
+      </React.Fragment>
+    )
   }
 }
 ```

--- a/react.md
+++ b/react.md
@@ -124,7 +124,7 @@ class Info extends React.Component {
 ```
 
 
-{: data-line="6,7"}
+{: data-line="5,6,7,8,9,10"}
 
 Nest components to separate concerns.
 
@@ -422,8 +422,11 @@ New features
 ------------
 {: .-three-column}
 
-### Returning fragments
+### Returning multiple elements
 
+You can return multiple elements as arrays or fragments.
+
+**Arrays**
 ```js
 render () {
   // Don't forget the keys!
@@ -435,7 +438,19 @@ render () {
 ```
 {: data-line="3,4,5,6"}
 
-You can return multiple nodes as arrays.
+**Fragments**
+```js
+render () {
+  // Fragments don't require keys!
+  return (
+    <React.Fragment>
+      <li>First item</li>
+      <li>Second item</li>
+    </React.Fragment>
+  )
+}
+```
+{: data-line="3,4,5,6,7,8"}
 
 See: [Fragments and strings](https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings)
 


### PR DESCRIPTION
IMHO, the previous example leads people to confusion into thinking that returning a element with a `<div>` and `<React.Fragment>` are equivalent, yet they aren't. This should clarify things up a bit and accentuate the difference.

Also, added the fragments example to the new features section.