### PR TITLE
correctly describe "$*", remove incorrect "$%"

### DIFF
--- a/makefile.md
+++ b/makefile.md
@@ -21,13 +21,12 @@ out.o: src.c src.h
   $^   # "src.c src.h" (all prerequisites)
 
 %.o: %.c
-  $%   # target member name ("foo" in "foo.c")
+  $*   # the 'stem' with which an implicit rule matches ("foo" in "foo.c")
 
 also:
   $+   # prerequisites (all, with duplication)
   $?   # prerequisites (new ones)
   $|   # prerequisites (order-only?)
-  $*   # basename without extension of the target (?)
 
   $(@D) # target directory
 ```


### PR DESCRIPTION
As documented in the [GNU Make manual](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html), `$%` is only used for files within archive files (which is a feature rarely used in my opinion). The automatic variable `$*` represents the matched part in implicit rules (%.o: %.c), e.g., "foo" for "foo.c".