### PR TITLE
[flow] modify minimal example to typing React components

### DIFF
--- a/flow.md
+++ b/flow.md
@@ -325,13 +325,16 @@ function add(n /*: number */) { ... }
 ### React
 
 ```js
-React$Element<any>
-```
+type Props = {
+  bar: number,
+}
 
-```js
-class Foo extends React.Component {
-  /*:: state: { open: boolean } */
-  /*:: props: { open: boolean } */
+type State = {
+  open: boolean,
+}
+
+class Foo extends React.Component<Props, State> {
+  // Component code
 }
 ```
 


### PR DESCRIPTION
This seems more reasonable, taken from the official Flow docs as well.