### PR TITLE
Fixed incorrect flow type output

### DIFF
--- a/flow.md
+++ b/flow.md
@@ -133,7 +133,7 @@ type Album = {
 ```js
 const a: Album = { } // ✓ OK
 a.name = 'Blue'      // ✓ OK
-a.name = null        // ✓ OK
+a.name = null        // ✓ Error
 a.name = undefined   // ✓ OK
 ```
 


### PR DESCRIPTION
This fixes an incorrect example in the flow cheatsheet. An explanation is below:

For an optional property, the property can either be undefined, otherwise must be any value that is not null. The example was showing  the incorrect output of a setting the value to null.

An example of the failure with the same example as in the sheet can be found here to be certain that this case does in fact throw an error:
https://flow.org/try/#0C4TwDgpgBAggNgIwK4FsoF4oG8BQUoB2AhihAPwBcUAzsAE4CWBA5jgL544DGA9gbVCJV4yNJixQ2UAPTSogZHIoAeQDSOIgDpipDFADkAIThIIe-OZlzFq9VpLRMBJHDgWLshcpUAaKAFUACygeIIBaQS5gJCIXEEIeYGCAa1ttBygkAgATCAAzJggs8w9rFSA