### PR TITLE
Fix typos

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -121,7 +121,7 @@ echo ${name}
 echo ${name/J/j}    #=> "john" (substitution)
 echo ${name:0:2}    #=> "jo" (slicing)
 echo ${name::2}     #=> "jo" (slicing)
-echo ${name::-1}    #=> "joh" (slicing)
+echo ${name::-1}    #=> "Joh" (slicing)
 echo ${food:-Cake}  #=> $food or "Cake"
 ```
 

--- a/bash.md
+++ b/bash.md
@@ -119,15 +119,15 @@ Parameter expansions
 name="John"
 echo ${name}
 echo ${name/J/j}    #=> "john" (substitution)
-echo ${name:0:2}    #=> "jo" (slicing)
-echo ${name::2}     #=> "jo" (slicing)
+echo ${name:0:2}    #=> "Jo" (slicing)
+echo ${name::2}     #=> "Jo" (slicing)
 echo ${name::-1}    #=> "Joh" (slicing)
 echo ${food:-Cake}  #=> $food or "Cake"
 ```
 
 ```bash
 length=2
-echo ${name:0:length}  #=> "jo"
+echo ${name:0:length}  #=> "Jo"
 ```
 
 See: [Parameter expansion](http://wiki.bash-hackers.org/syntax/pe)


### PR DESCRIPTION
Outputs for some of the Bash examples should be uppercase, but currently are lowercase. => Fixed that.