### PR TITLE
props() returns all props, prop('key') returns a single prop

### DIFF
--- a/enzyme.md
+++ b/enzyme.md
@@ -248,7 +248,7 @@ wrap.context()       // get full context
 
 ```js
 wrap.state('key')    // → any
-wrap.props('key')    // → any
+wrap.prop('key')    // → any
 wrap.context('key')  // → any
 ```
 


### PR DESCRIPTION
See https://airbnb.io/enzyme/docs/api/ShallowWrapper/prop.html