### PR TITLE
Update composer.md

### DIFF
--- a/composer.md
+++ b/composer.md
@@ -30,6 +30,7 @@ All composer commands, depending on your install, may need to use `php composer.
 | ---                       | ---                             |
 | `composer update laravel` | Update a certain package        |
 | `composer update vendor/*`| Update all packages in a folder |
+| `composer update --lock`  | Update lock file hash without updating any packages |
 
 
 


### PR DESCRIPTION
`update --lock` is useful e.g. after resolving merge conflicts when the packages should stay at their current versions but the lock file hash is invalid and must be updated.