### PR TITLE
fixed refs format variable on git-log

### DIFF
--- a/git-log-format.md
+++ b/git-log-format.md
@@ -54,7 +54,7 @@ See the next tables on format variables.
 | `%f` | commit subject, filename style |
 | `%b` | commit body |
 | --- | --- |
-| `%cd` | ref names |
+| `%d` | ref names |
 | `%e` | encoding |
 
 ## Author and committer


### PR DESCRIPTION
Said `%cd` and should be `%d`