### PR TITLE
factory_bot: Update static attributes using dynamic

### DIFF
--- a/factory_bot.md
+++ b/factory_bot.md
@@ -3,7 +3,7 @@ title: Factory Bot
 category: Ruby libraries
 layout: 2017/sheet
 weight: -3
-updated: 2017-10-31
+updated: 2018-08-30
 keywords:
   - "FactoryBot.define do"
   - "factory :user"
@@ -23,10 +23,10 @@ intro: |
 ```ruby
 FactoryBot.define do
   factory :user do
-    first_name 'John'
-    last_name  'Doe'
+    first_name { 'John' }
+    last_name  { 'Doe' }
     birthdate  { 21.years.ago }
-    admin false
+    admin { false }
 
     sequence(:username) { |n| "user#{n}" }
   end
@@ -124,7 +124,7 @@ end
 ```ruby
 factory :user do
   trait :admin do
-    admin true
+    admin { true }
   end
 end
 ```
@@ -141,7 +141,7 @@ See: [Traits](http://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md#T
 
 ```ruby
 factory :user do
-  first_name 'John'
+  first_name { 'John' }
 
   factory :sample_user do
     first_name { FFaker::Name.first_name }
@@ -182,7 +182,7 @@ Works the same as nested factories.
 ```ruby
 factory :user do
   transient do
-    upcased true
+    upcased { true }
   end
 
   after :create do |user, options|

--- a/factory_bot.md
+++ b/factory_bot.md
@@ -3,7 +3,7 @@ title: Factory Bot
 category: Ruby libraries
 layout: 2017/sheet
 weight: -3
-updated: 2018-08-30
+updated: 2020-06-24
 keywords:
   - "FactoryBot.define do"
   - "factory :user"


### PR DESCRIPTION
Update static attributes using dynamic instead of deprecated one. Static attributes, without a block, are deprecated and will be removed in factory_bot 5.

example of deprecated static attribute:
`  admin true`

example of dynamic attribute:
` admin { true }`


more read : 
- https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#static-attributes