### PR TITLE
Typo fix - knex.md

### DIFF
--- a/knex.md
+++ b/knex.md
@@ -43,7 +43,7 @@ knex('users')
 ```
 {: data-line="2"}
 
-See: [Select](#elect-1)
+See: [Select](#select-1)
 
 ### Insert
 


### PR DESCRIPTION
Fix typo in "select" anchor