### PR TITLE
Fix "Factory Girl" category

### DIFF
--- a/factory_girl.md
+++ b/factory_girl.md
@@ -1,5 +1,5 @@
 ---
 title: Factory Girl
-category: JavaScript libraries
+category: Ruby libraries
 redirect_to: /factory_bot
 ---


### PR DESCRIPTION
It was incorrectly categorized as a JavaScript library, but it was meant to be a Ruby library