### PR TITLE
find: Include file size conditions

### DIFF
--- a/find.md
+++ b/find.md
@@ -34,6 +34,14 @@ find <path> <conditions> <actions>
 ```
 
 ```bash
+-size 8            # Exactly 8 512-bit blocks 
+-size -128c        # Smaller than 128 bytes
+-size 1440k        # Exactly 1440KiB
+-size +10M         # Larger than 10MiB
+-size +2G          # Larger than 2GiB
+```
+
+```bash
 -newer   file.txt
 -newerm  file.txt        # modified newer than file.txt
 -newerX  file.txt        # [c]hange, [m]odified, [B]create


### PR DESCRIPTION
The units of the size command are not straight-forward. The default
file size unit is counter-intuitively 512-bit blocks. This patch
includes a cheat sheet for the ability to filter files based on its
size and the various units that are accepted by the find command.