### PR TITLE
jsdoc.md: Fixed Types table

### DIFF
--- a/jsdoc.md
+++ b/jsdoc.md
@@ -31,7 +31,7 @@ See: <http://usejsdoc.org/index.html>
 | ---                          | ---                   |
 | `@param {string=} n`         | Optional              |
 | `@param {string} [n]`        | Optional              |
-| `@param {(string|number)} n` | Multiple types        |
+| `@param {(string\|number)} n`| Multiple types        |
 | `@param {*} n`               | Any type              |
 | `@param {...string} n`       | Repeatable arguments  |
 | `@param {string} [n="hi"]`   | Optional with default |


### PR DESCRIPTION
Escape the '|' in the "Multiple types" row.