### PR TITLE
Invalid options for set builtin

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -482,7 +482,7 @@ set -o nounset    # Exposes unset variables
 set -o nullglob    # Non-matching globs are removed  ('*.foo' => '')
 set -o failglob    # Non-matching globs throw errors
 set -o nocaseglob  # Case insensitive globs
-set -o globdots    # Wildcards match dotfiles ("*.sh" => ".foo.sh")
+set -o dotglob     # Wildcards match dotfiles ("*.sh" => ".foo.sh")
 set -o globstar    # Allow ** for recursive matches ('lib/**/*.rb' => 'lib/a/b/c.rb')
 ```
 

--- a/bash.md
+++ b/bash.md
@@ -479,7 +479,7 @@ set -o nounset    # Exposes unset variables
 ### Glob options
 
 ```bash
-set -o nullglob    # Non-matching globs are removed  ('*.foo' => '')
+shopt -s nullglob  # Non-matching globs are removed  ('*.foo' => '')
 set -o failglob    # Non-matching globs throw errors
 set -o nocaseglob  # Case insensitive globs
 set -o dotglob     # Wildcards match dotfiles ("*.sh" => ".foo.sh")


### PR DESCRIPTION
Bash has a `dotglob` option for dotfiles globbing.