### PR TITLE
Correct description of ":=" and "=" operators

### DIFF
--- a/makefile.md
+++ b/makefile.md
@@ -8,10 +8,12 @@ category: CLI
 ## Var assignment
 
 ```makefile
-uglify = $(uglify)        # assignment (right hand side is evaluated when variable is used)
-compressor := $(uglify)   # immediate assignment (right hand side is evaluated at assignment)
+uglify = $(uglify)        # lazy assignment
+compressor := $(uglify)   # immediate assignment
 prefix ?= /usr/local      # safe assignment
 ```
+
+`=` expressions are only evaluated when they're being used.
 
 ## Magic variables
 

--- a/makefile.md
+++ b/makefile.md
@@ -8,8 +8,8 @@ category: CLI
 ## Var assignment
 
 ```makefile
-uglify = $(uglify)        # assignment
-compressor := $(uglify)   # lazy assignment
+uglify = $(uglify)        # assignment (right hand side is evaluated when variable is used)
+compressor := $(uglify)   # immediate assignment (right hand side is evaluated at assignment)
 prefix ?= /usr/local      # safe assignment
 ```
 


### PR DESCRIPTION
Fixes #992 

The description of the ":=" and "=" assignment operators were flipped. As documented in the GNU make manual (https://www.gnu.org/software/make/manual/make.html#Reading-Makefiles), the ":=" assignment operatory is the immediate assignment operation and "=" is the deferred assignment operation. This change switches the descriptions to correspond to the correct operator and augments the description to clarify the behaviour.