### PR TITLE
Simplify catching errors paragraph

### DIFF
--- a/js-fetch.md
+++ b/js-fetch.md
@@ -65,7 +65,7 @@ fetch('/data.json')
 
 ```js
 function checkStatus (res) {
-  if (res.status >= 200 && res.status < 300) {
+  if (res.ok) {
     return res
   } else {
     let err = new Error(res.statusText)


### PR DESCRIPTION
Checking if the status code of the response is a 2XX code is the same as checking Response.ok, as Response.ok returns true when the status code is in the range 200-299 (see https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)