### PR TITLE
Update date time fields due to deprecation

### DIFF
--- a/phoenix-migrations.md
+++ b/phoenix-migrations.md
@@ -44,7 +44,7 @@ create table(:documents) do
   add :age, :integer
   add :price, :float
   add :price, :float, precision: 10, scale: 2
-  add :published_at, :datetime
+  add :published_at, :utc_datetime  # naive_datetime is also available
   add :group_id, references(:groups)
   add :object, :json
 


### PR DESCRIPTION
The datetime type has been deprecated and utc_datetime or naive_datetime should be used instead.