### PR TITLE
flow: Update doc links

### DIFF
--- a/flow.md
+++ b/flow.md
@@ -196,7 +196,7 @@ type Items = {
 ```
 {: data-line="2"}
 
-See: [Dynamic object keys](https://flow.org/docs/objects.html#objects-as-maps)
+See: [Dynamic object keys](https://flow.org/en/docs/types/objects/#toc-objects-as-maps)
 
 ## Advanced features
 
@@ -237,7 +237,7 @@ const countries = {
 type Country = $Keys<typeof countries>
 ```
 
-See: [Enums](https://flow.org/docs/utility-types.html#keyst)
+See: [Enums](https://flow.org/en/docs/types/utilities/#toc-keys)
 
 ### Type aliases
 
@@ -253,7 +253,7 @@ type Generic<T> = {
 }
 ```
 
-See: [Type aliases](https://flow.org/docs/quick-reference.html#type-aliases)
+See: [Type aliases](https://flow.org/en/docs/types/aliases/)
 
 ### Generic classes
 
@@ -266,7 +266,7 @@ class GenericClass<T> {
 var n: GenericClass<number> = new GenericClass(0)
 ```
 
-See: [Generic classes](https://flow.org/docs/quick-reference.html#generics)
+See: [Generic classes](https://flow.org/en/docs/types/generics/#toc-classes-with-generics)
 
 ### Interfaces
 
@@ -282,7 +282,7 @@ class Foo {
 (new Foo: Jsonable)
 ```
 
-See: [Interfaces](https://flow.org/docs/quick-reference.html#interfaces)
+See: [Interfaces](https://flow.org/en/docs/types/interfaces/)
 
 ### Functions
 
@@ -299,7 +299,7 @@ function filter<T> (
 }
 ```
 
-See: [Functions](https://flow.org/docs/functions.html)
+See: [Functions](https://flow.org/en/docs/types/functions/)
 
 ### Imports
 


### PR DESCRIPTION
Update doc links in `flow.md`:

* Dynamic object keys 
* Enums
* Type aliases
* Generic classes
* Interfaces
* Functions