### PR TITLE
Fix bash substring from right example

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -193,7 +193,7 @@ comment
 ### Substrings
 
 | `${FOO:0:3}`  | Substring _(position, length)_ |
-| `${FOO:-3:3}` | Substring from the right |
+| `${FOO:(-3):3}` | Substring from the right |
 
 ### Length
 


### PR DESCRIPTION
Example invalid due to bash interpreting it as default value, not slicing operation.