### PR TITLE
MomentJS: Only 12 months for `Mo`.

### DIFF
--- a/_includes/common/moment_format.md
+++ b/_includes/common/moment_format.md
@@ -33,7 +33,7 @@ Used by [Moment.js](http://momentjs.com/docs/#/displaying/) and [date-fns/format
 | `YYYY` | `2013`                  |                  |
 | ---    | ---                     | ---              |
 | `M`    | `1`..`12` _(Jan is 1)_  | **Month**        |
-| `Mo`   | `1st`..`31st`           |                  |
+| `Mo`   | `1st`..`12th`           |                  |
 | `MM`   | `01`..`12` _(Jan is 1)_ |                  |
 | `MMM`  | `Jan`                   |                  |
 | `MMMM` | `January`               |                  |


### PR DESCRIPTION
Fixed format's to correct `Mo` example column (previously listed "1st..31st"; now only goes up to 12th).