### PR TITLE
Update pacman.md to correct "Uninstall" command

### DIFF
--- a/pacman.md
+++ b/pacman.md
@@ -15,7 +15,7 @@ intro: |
 | ----------------------- | --------------------------------- |
 | `pacman -Syu <pkg>`     | Install (and update package list) |
 | `pacman -S <pkg>`       | Install only                      |
-| `pacman -Rsc <pkg>`     | Uninstall                         |
+| `pacman -Rs <pkg>`      | Uninstall                         |
 | `pacman -Ss <keywords>` | Search                            |
 | `pacman -Syu`           | Upgrade everything                |
 {: .-prime}
@@ -51,4 +51,5 @@ Avoid orphans by using `pacman -Rsc` to remove packages, which will remove unnee
 
 ### References
 
+* [Pacman](https://wiki.archlinux.org/index.php/Pacman) _(wiki.archlinux.org)_
 * [Pacman tips and tricks](https://wiki.archlinux.org/index.php/Pacman/Tips_and_tricks) _(wiki.archlinux.org)_


### PR DESCRIPTION
From the Pacman page on the archwiki (which I added as reference too; emphasis mine):

> To remove a package, its dependencies and **all the packages that depend on the target package**:
> Warning: This operation is recursive, and must be used with care since it **can remove many potentially needed packages**.
> `# pacman -Rsc package_name`

Since there's a big red warning that this might break your system, I think you really want the non-recursive pacman -Rs command
(NB: The added -s just removes unneeded packages that nothing depends on & weren't explicitly installed by the user)