### PR TITLE
--update: outdated jsdoc domain.

### DIFF
--- a/jsdoc.md
+++ b/jsdoc.md
@@ -23,7 +23,7 @@ weight: -1
 function foo(n) { return n }
 ```
 
-See: <http://usejsdoc.org/index.html>
+See: <https://jsdoc.app/index.html>
 
 ### Types
 
@@ -37,7 +37,7 @@ See: <http://usejsdoc.org/index.html>
 | `@param {string} [n="hi"]`   | Optional with default |
 | `@param {string[]} n`        | Array of strings      |
 
-See: <http://usejsdoc.org/tags-type.html>
+See: <https://jsdoc.app/tags-type.html>
 
 ### Variables
 
@@ -77,7 +77,7 @@ function play (song) {
 }
 ```
 
-See: <http://usejsdoc.org/tags-typedef.html>
+See: <https://jsdoc.app/tags-typedef.html>
 
 ### Importing types
 
@@ -118,4 +118,4 @@ This syntax is [TypeScript-specific](https://github.com/Microsoft/TypeScript/wik
  */
 ```
 
-Prefer `alias` over `name`. See: <http://usejsdoc.org/tags-alias.html>
+Prefer `alias` over `name`. See: <https://jsdoc.app/tags-alias.html>


### PR DESCRIPTION
jsdoc has updated it domain.
<img width="1228" alt="Screenshot 2019-05-22 at 16 36 16" src="https://user-images.githubusercontent.com/3696327/58183513-c2277e80-7caf-11e9-9d8a-a4779f3ed4e7.png">

The old domain is not reachable
<img width="1092" alt="Screenshot 2019-05-22 at 16 34 43" src="https://user-images.githubusercontent.com/3696327/58183535-cd7aaa00-7caf-11e9-92c5-10673863cf2a.png">

Therefore, it is required to update the references to jsdoc.

