### PR TITLE
Fix Typo in Golang cheatsheet # Methods -> Receivers

### DIFF
--- a/go.md
+++ b/go.md
@@ -494,7 +494,7 @@ func (v Vertex) Abs() float64 {
 {: data-line="1"}
 
 ```go
-v: = Vertex{1, 2}
+v := Vertex{1, 2}
 v.Abs()
 ```
 


### PR DESCRIPTION
Fix a Very small error in # Methods -> Receivers