### PR TITLE
Update jsdoc link to new domain

### DIFF
--- a/jsdoc.md
+++ b/jsdoc.md
@@ -23,7 +23,7 @@ weight: -1
 function foo(n) { return n }
 ```
 
-See: <http://usejsdoc.org/index.html>
+See: <http://jsdoc.app/index.html>
 
 ### Types
 
@@ -37,7 +37,7 @@ See: <http://usejsdoc.org/index.html>
 | `@param {string} [n="hi"]`   | Optional with default |
 | `@param {string[]} n`        | Array of strings      |
 
-See: <http://usejsdoc.org/tags-type.html>
+See: <http://jsdoc.app/tags-type.html>
 
 ### Variables
 
@@ -77,7 +77,7 @@ function play (song) {
 }
 ```
 
-See: <http://usejsdoc.org/tags-typedef.html>
+See: <http://jsdoc.app/tags-typedef.html>
 
 ### Importing types
 
@@ -118,4 +118,4 @@ This syntax is [TypeScript-specific](https://github.com/Microsoft/TypeScript/wik
  */
 ```
 
-Prefer `alias` over `name`. See: <http://usejsdoc.org/tags-alias.html>
+Prefer `alias` over `name`. See: <http://jsdoc.appg/tags-alias.html>


### PR DESCRIPTION
Update jsdoc link to new domain.

https://github.com/jsdoc/jsdoc/commit/b8012f482d3c26eaca84d27d7ce7e8dc98687b69#diff-8b1c3fd0d4a6765c16dfd18509182f9dR76