### PR TITLE
bash: Correct mistakes at $RANDOM

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -604,7 +604,7 @@ $((a + 200))      # Add 200 to $a
 ```
 
 ```bash
-$((RANDOM%=200))  # Random number 0..200
+$(($RANDOM%200))  # Random number 0..199
 ```
 
 ### Subshells


### PR DESCRIPTION
- using `=` just throws an error!
- `200` limits the result to 200 possible numbers starting with 0! so the maximum is 199.
- added `$` straight before `RANDOM` to be on the safe side.