### PR TITLE
xpath: Fix nesting predicates

### DIFF
--- a/xpath.md
+++ b/xpath.md
@@ -232,7 +232,7 @@ Order is significant, these two are different.
 ### Nesting predicates
 
 ```
-//section[//h1[@id='hi']]
+//section[.//h1[@id='hi']]
 ```
 
 This returns `<section>` if it has an `<h1>` descendant with `id='hi'`.


### PR DESCRIPTION
we need to use `.//` instead of `//` inside the predicate

Before: `//section[//h1[@id='hi']]` -- This returns `<section>` if **document** has an `<h1>` with `id='hi'`.

After: `//section[.//h1[@id='hi']]` This returns `<section>` if it has an `<h1>` **descendant** with `id='hi'`.
