### PR TITLE
OSX spotlight and system utils changes

### DIFF
--- a/osx.md
+++ b/osx.md
@@ -32,10 +32,10 @@ category: macOS
     killall -HUP mDNSResponder   # 10.8+
     dscacheutil -flushcache      # 10.7 below
 
-### Turn off spotlight
+### Disable spotlight indexing
 
-    sudo vim /etc/hostconfig  # change SPOTLIGHT=-YES- to SPOTLIGHT=-NO-
-    mdutil -i off /
+    mdutil -a -i off                    # until next reboot on all volumes
+    touch FOLDER/.metadata_never_index  # if this file exists in FOLDER only for that FOLDER
 
 ### Turn on/off proxy
 
@@ -49,8 +49,8 @@ category: macOS
 ### System utils
 
  - `networksetup` - Configure network (ip, dns, proxy, etc)
- - `tmutils` - Configure Time Machine (enable/disable, exclude path, delete snapshots, etc)
- - `mdutils` - Manage Spotlight (enable/disable, exclude, etc)
+ - `tmutil` - Configure Time Machine (enable/disable, exclude path, delete snapshots, etc)
+ - `mdutil` - Manage Spotlight (enable/disable, exclude, etc)
  - `diskutil` - Control disk (format, eject, unmount, etc)
  - `launchctl` - Control running "agents"
 

--- a/osx.md
+++ b/osx.md
@@ -34,8 +34,10 @@ category: macOS
 
 ### Disable spotlight indexing
 
-    mdutil -a -i off                    # until next reboot on all volumes
-    touch FOLDER/.metadata_never_index  # if this file exists in FOLDER only for that FOLDER
+    mdutil -a -i off                    # disable indexing for all volumes
+    mdutil -i off MOUNT_POINT           # disable for specific volume
+    touch FOLDER/.metadata_never_index  # disable for FOLDER
+                                        
 
 ### Turn on/off proxy
 


### PR DESCRIPTION
- /etc/hostconfig is not supported anymore since Yosemite
- added 3 options to disable spotlight indexing
- fixed system utils typos.