### PR TITLE
Added alternate way of triggering events

### DIFF
--- a/enzyme.md
+++ b/enzyme.md
@@ -136,6 +136,12 @@ wrap.find('input').simulate('change', {
 })
 ```
 
+#### Alternate way of triggering events
+
+```js
+wrap.find('input').prop('onChange')();
+```
+
 ## Installing
 
 ### Initial setup


### PR DESCRIPTION
`.simulate` is depreciated and will be removed in the future. Adding alternate methods to the cheatsheet will make it more complete. See https://github.com/airbnb/enzyme/issues/2173