### PR TITLE
Remove Homebrew Cask Link

### DIFF
--- a/homebrew.md
+++ b/homebrew.md
@@ -41,5 +41,4 @@ category: CLI
 
 * [Homebrew homepage](https://brew.sh/) _brew.sh_
 * [Homebrew docs](https://docs.brew.sh) _docs.brew.sh_
-* [Homebrew Cask](https://caskroom.github.io/) _caskroom.github.io_
 {: .-also-see}


### PR DESCRIPTION
Remove the Homebrew Cask Link as it just redirects to https://brew.sh/ link.