### PR TITLE
Update obs. Enzyme methods 'getNode' & 'getNodes'

### DIFF
--- a/enzyme.md
+++ b/enzyme.md
@@ -219,8 +219,8 @@ wrap.last()           // → ReactWrapper
 
 ```js
 wrap.get(0)           // → ReactElement
-wrap.getNode()        // → ReactElement
-wrap.getNodes()       // → Array<ReactElement>
+wrap.getElement()        // → ReactElement
+wrap.getElements()       // → Array<ReactElement>
 wrap.getDOMNode()     // → DOMComponent
 ```
 

--- a/enzyme.md
+++ b/enzyme.md
@@ -219,8 +219,8 @@ wrap.last()           // → ReactWrapper
 
 ```js
 wrap.get(0)           // → ReactElement
-wrap.getElement()        // → ReactElement
-wrap.getElements()       // → Array<ReactElement>
+wrap.getElement()     // → ReactElement
+wrap.getElements()    // → Array<ReactElement>
 wrap.getDOMNode()     // → DOMComponent
 ```
 


### PR DESCRIPTION
`getNode` and `getNodes` methods are depreciated and no longer in use. They are renamed to `getElement` and `getElements` instead. 

See Enzyme docs here: 
- https://airbnb.io/enzyme/docs/api/ShallowWrapper/getElement.html
- https://airbnb.io/enzyme/docs/api/ShallowWrapper/getElements.html