### PR TITLE
fix tmux pane creations

### DIFF
--- a/tmux.md
+++ b/tmux.md
@@ -44,8 +44,8 @@ category: CLI
 
 ### Panes
 
-    C-b v       # vert
-    C-b n       # horiz
+    C-b %       # vert
+    C-b "       # horiz
     C-b hkjl    # navigation
     C-b HJKL    # resize
     C-b o       # next window


### PR DESCRIPTION
tried on fedora 30 and mac os mojave (tmux from brew), horizontal pane are **C-b "** and vertical pane are **C-b %**