### PR TITLE
Update xpath.md

### DIFF
--- a/xpath.md
+++ b/xpath.md
@@ -18,7 +18,7 @@ Test queries in the Xpath test bed:<br>
 ### Browser console
 
 ```js
-$x('//div')
+$x("//div")
 ```
 
 Works in Firefox and Chrome.


### PR DESCRIPTION
Single quotation marks does not work in Chrome but double works in Firefox and Chrome