### PR TITLE
Added aws configuration profile option

### DIFF
--- a/awscli.md
+++ b/awscli.md
@@ -37,6 +37,13 @@ brew install awscli
 aws configure
 ```
 
+### Configuration profiles
+
+```
+aws configure --profile project1
+aws configure --profile project2
+```
+
 ## Elastic Beanstalk
 
 ### Configuration


### PR DESCRIPTION
Using multiple aws credentials is a very common scenario, so hinting to the `--profile` option is highly encouraged.