### PR TITLE
Added missing ')'

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -415,7 +415,7 @@ numbers.map(n => n * 2)
 // Same as: numbers.map(function (n) { return n * 2 })
 numbers.map(n => ({
   result: n * 2
-})
+}))
 // Implicitly returning objects requires parentheses around the object
 ```
 {: data-line="1,4,5,6"}


### PR DESCRIPTION
Added missing ')' at the end of `fat arrow` example