### PR TITLE
Added match a single character that is not contained within the brack…

### DIFF
--- a/regexp.md
+++ b/regexp.md
@@ -5,7 +5,8 @@ layout: 2017/sheet
 weight: -1
 authors:
   - github: rizqyhi
-updated: 2019-03-24
+  - github: samtrion
+updated: 2019-11-14
 description: |
   Basic cheatsheets for regular expression
 ---
@@ -16,18 +17,19 @@ description: |
 
 ### Character classes
 
-| Pattern | Description                    |
-| ------- | ------------------------------ |
-| `.`     | Any character, except newline  |
-| `\w`    | Word                           |
-| `\d`    | Digit                          |
-| `\s`    | Whitespace                     |
-| `\W`    | Not word                       |
-| `\D`    | Not digit                      |
-| `\S`    | Not whitespace                 |
-| `[abc]` | Any of a, b, or c              |
-| `[a-e]` | Characters between `a` and `e` |
-| `[1-9]` | Digit between `1` and `9`      |
+| Pattern  | Description                     |
+| -------- | ------------------------------- |
+| `.`      | Any character, except newline   |
+| `\w`     | Word                            |
+| `\d`     | Digit                           |
+| `\s`     | Whitespace                      |
+| `\W`     | Not word                        |
+| `\D`     | Not digit                       |
+| `\S`     | Not whitespace                  |
+| `[abc]`  | Any of a, b, or c               |
+| `[a-e]`  | Characters between `a` and `e`  |
+| `[1-9]`  | Digit between `1` and `9`       |
+| `[^abc]` | Any character except a, b and c |
 
 ### Anchors
 


### PR DESCRIPTION
…ets. For example, [^abc]

Matches a single character that is not contained within the brackets. For example, [^abc] matches any character other than "a", "b", or "c". [^a-z] matches any single character that is not a lowercase letter from "a" to "z". Likewise, literal characters and ranges can be mixed.