### PR TITLE
Fix ports syntax

### DIFF
--- a/docker-compose.md
+++ b/docker-compose.md
@@ -79,7 +79,7 @@ web:
 ```yaml
   ports:
     - "3000"
-    - "8000:80"  # guest:host
+    - "8000:80"  # host:container
 ```
 
 ```yaml


### PR DESCRIPTION
> SHORT SYNTAX
> Either specify both ports (HOST:CONTAINER), or just the container port (an ephemeral host port is chosen).

https://docs.docker.com/compose/compose-file/