### PR TITLE
Fix JSDoc function param with multiple types

### DIFF
--- a/jsdoc.md
+++ b/jsdoc.md
@@ -31,7 +31,7 @@ See: <http://usejsdoc.org/index.html>
 | ---                          | ---                   |
 | `@param {string=} n`         | Optional              |
 | `@param {string} [n]`        | Optional              |
-| `@param {(string\|number)} n`| Multiple types        |
+| `@param {(string|number)} n` | Multiple types        |
 | `@param {*} n`               | Any type              |
 | `@param {...string} n`       | Repeatable arguments  |
 | `@param {string} [n="hi"]`   | Optional with default |


### PR DESCRIPTION
Fixed what I think is a typo based on this:

https://jsdoc.app/tags-param.html#multiple-types-and-repeatable-parameters