### PR TITLE
gitpod: Cache 'bundle install'

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,10 @@
 image: gitpod/workspace-full
 
+github:
+  # Prebuild the docker image for gitpod - https://www.gitpod.io/docs/46_prebuilds/
+  prebuilds:
+    # enable for the master/default branch
+    master: true
+
 tasks:
   - init: bundle install


### PR DESCRIPTION
This is going to cache `bundle install` dependencies in docker image that is used for gitpod so that contributors doesn't have to wait for it to finish on each run. (Makes the environment to be instantly ready for work instead of waiting 57 seconds)

**Heads-up:** This requires authentification from https://github.com/marketplace/gitpod-io/ to be allowed for this repository.