### PR TITLE
Update and rename vue.md to vue@1.0.28.md

### DIFF
--- a/vue@1.0.28.md
+++ b/vue@1.0.28.md
@@ -5,7 +5,7 @@ layout: 2017/sheet
 updated: 2019-11-22
 weight: -10
 intro: |
-  [Vue.js](https://vuejs.org/) is an open-source Model–view–viewmodel JavaScript framework for building user interfaces and single-page applications.
+  [Vue.js (v1.0.28)](https://v1.vuejs.org/) is an open-source Model–view–viewmodel JavaScript framework for building user interfaces and single-page applications.
 ---
 
 {% raw %}


### PR DESCRIPTION
This PR shows that the cheatsheet is for an older version of Vue.js which is v1.0.28.
Maybe we could also make it deprecated and create a new cheatsheet for the new version.