### PR TITLE
Fixed tmux attach.

### DIFF
--- a/tmux.md
+++ b/tmux.md
@@ -15,7 +15,7 @@ category: CLI
     $ tmux new -s session_name
 
     $ tmux attach # Default session
-    $ tmux attach -s session_name
+    $ tmux attach -t session_name
 
     $ tmux switch -t session_name
 


### PR DESCRIPTION
Was originally -s instead of -t, so it would not work.

This fixes it.