### PR TITLE
bash: fix line reading example

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -260,7 +260,7 @@ done
 ### Reading lines
 
 ```bash
-< file.txt | while read line; do
+cat file.txt | while read line; do
   echo $line
 done
 ```


### PR DESCRIPTION
`< file.txt | cmd` only works in zsh, not bash (as of bash 5.0.11).