### PR TITLE
Updated accessing a single prop's value

### DIFF
--- a/enzyme.md
+++ b/enzyme.md
@@ -83,7 +83,7 @@ wrap.setState({ show: true })
 #### Asserting
 
 ```js
-expect(wrap.props('name')).toEqual('Moe')
+expect(wrap.prop('name')).toEqual('Moe')
 expect(wrap.state('show')).toEqual(true)
 ```
 


### PR DESCRIPTION
Instead of `.props('name')`, use `.prop('name')` to access a single prop's value for testing