### PR TITLE
vim: Fix two minor errors

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -43,7 +43,7 @@ Getting started
 #### Words
 
 | Shortcut     | Description               |
-ff| ---          | ---                       |
+| ---          | ---                       |
 | `b` _/_ `w`  | Previous/next word        |
 | `ge` _/_ `e` | Previous/next end of word |
 {: .-shortcuts}
@@ -367,7 +367,7 @@ Do these in visual or normal mode.
 | `.`        | Repeat last command                               |
 | `]p`       | Paste under the current indentation level         |
 | ---        | ---                                               |
-| `:ff=unix` | Convert Windows line endings to Unix line endings |
+| `:set ff=unix` | Convert Windows line endings to Unix line endings |
 {: .-shortcuts}
 
 ### Command line


### PR DESCRIPTION
• `:ff=unix` → `:set ff=unix`
• Remove random `ff` from navigation table as it was messing up the formatting:
![image](https://user-images.githubusercontent.com/6967592/75121469-1e2e9180-568c-11ea-9f23-c24b376de45c.png)
