### PR TITLE
phoenix-migrations: changed precision to apply to decimal

### DIFF
--- a/phoenix-migrations.md
+++ b/phoenix-migrations.md
@@ -49,7 +49,8 @@ create table(:documents) do
   add :body, :text
   add :age, :integer
   add :price, :float
-  add :price, :float, precision: 10, scale: 2
+  add :price, :float
+  add :price, :decimal, precision: 10, scale: 2
   add :published_at, :utc_datetime
   add :group_id, references(:groups)
   add :object, :json


### PR DESCRIPTION
adding `precision: 10, scale: 2` will result in an exception on migration due to malformed sql. precision and scale apply to decimal