### PR TITLE
React Hooks: Add deps to useEffect

### DIFF
--- a/react.md
+++ b/react.md
@@ -365,7 +365,7 @@ function Example() {
   useEffect(() => {
     // Update the document title using the browser API
     document.title = `You clicked ${count} times`;
-  });
+  }, [count]);
 
   return (
     <div>
@@ -379,7 +379,7 @@ function Example() {
 ```
 {: data-line="6,7,8,9,10"}
 
-If you’re familiar with React class lifecycle methods, you can think of `useEffect` Hook as `componentDidMount`, `componentDidUpdate`, and `componentWillUnmount` combined. 
+If you’re familiar with React class lifecycle methods, you can think of `useEffect` Hook as `componentDidMount`, `componentDidUpdate`, and `componentWillUnmount` combined.
 
 By default, React runs the effects after every render — including the first render.
 
@@ -401,7 +401,7 @@ function FriendStatus(props) {
     return () => {
       ChatAPI.unsubscribeFromFriendStatus(props.friend.id, handleStatusChange);
     };
-  });
+  }, [props.friend.id]);
 
   if (isOnline === null) {
     return 'Loading...';


### PR DESCRIPTION
While it works for this example, it's usually an error to leave out the dependencies; it would run the effect every render, even when the relevant values did not change.

We can add more explanation for the deps part, but I think it's a low-hanging fruit for a cheatsheet.