### PR TITLE
Update capybara.md - click => click_on

### DIFF
--- a/capybara.md
+++ b/capybara.md
@@ -13,7 +13,7 @@ tags: [Featurable]
 
 ### Clicking links and buttons
 
-    click 'Link Text'
+    click_on 'Link Text'
     click_button
     click_link
 

--- a/capybara.md
+++ b/capybara.md
@@ -13,9 +13,11 @@ tags: [Featurable]
 
 ### Clicking links and buttons
 
-    click_on 'Link Text'
-    click_button
-    click_link
+```ruby
+click_on 'Link Text'
+click_button
+click_link
+```
 
 ### Interacting with forms
 


### PR DESCRIPTION
Capybara renamed click to click_on

[From their history](https://github.com/teamcapybara/capybara/blob/master/History.md): 

> 
> Version 0.4.0.rc
> Session#click has been renamed click_link_or_button and the old click has been deprecated
> 
> Version 0.4.1
> New click_on alias for click_link_or_button, shorter yet unambiguous. [Jonas Nicklas]

