### PR TITLE
Use example.com instead of service.com

### DIFF
--- a/rest-api.md
+++ b/rest-api.md
@@ -48,7 +48,7 @@ You can pass a `version=x` to the Accept request header. [Info here](https://git
 ### Authentication
 
 ```
-curl -is https://$TOKEN@api.service.com/
+curl -is https://$TOKEN@api.example.com/
 ```
 
 ### Methods


### PR DESCRIPTION
service.com is a real domain name, and could potentially have a real API on api.service.com

example.com is specifically reserved by IANA and thus will never have an API on it. It is designated to be used in scenarios like this. See [RFC 2606](https://tools.ietf.org/html/rfc2606#section-3) for more information.