### PR TITLE
Remove duplicate MIT license line from Badges

### DIFF
--- a/badges.md
+++ b/badges.md
@@ -37,8 +37,6 @@ Here are some badges for open source projects.
 
     [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
-    [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
-
 ### Support stuff
 
     Support


### PR DESCRIPTION
A second copy of the MIT license badge seems to have slipped in right after the first one.