### PR TITLE
emmet: Fixed a typo in Emmet Cheatsheet

### DIFF
--- a/emmet.md
+++ b/emmet.md
@@ -31,7 +31,7 @@ section>p+p+p
 Expands to
 ```html
 <section>
-  <pt></p>
+  <p></p>
   <p></p>
   <p></p>
 </section>


### PR DESCRIPTION
Fixed a typo in emmet
section>p gives <section><p>...</p></section>
Earlier it was <section><pt>....</p></section>