### PR TITLE
vim: Added '%' as a quick delimiter navigator

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -293,6 +293,7 @@ Uppercase ones are recursive (eg, `zO` is open recursively).
 
 | Shortcut            | Description                |
 | ---                 | ---                        |
+| `%`                 | Nearest/matching `{[()]}`  |
 | `[(` `[{` `[<`      | Previous `(` or `{` or `<` |
 | `])`                | Next                       |
 | ---                 | ---                        |


### PR DESCRIPTION
Works pour `{}`, `()`, `[]` and also `/* */`, `#ifdef` and other usual delimiters
in programming languages. See ':help %'.