### PR TITLE
Bash: add `else` example

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -404,6 +404,8 @@ if [[ -z "$string" ]]; then
   echo "String is empty"
 elif [[ -n "$string" ]]; then
   echo "String is not empty"
+else
+  echo "This never happens"
 fi
 ```
 


### PR DESCRIPTION
I always forget if `else` is to be followed by a `;` or not. Add it to the conditionals chapter where I would expect it.