### PR TITLE
Fix aria-hidden elements

### DIFF
--- a/_sass/2017/base/base.scss
+++ b/_sass/2017/base/base.scss
@@ -55,11 +55,6 @@ a:hover {
   color: $base-b3;
 }
 
-/* prism.js adds area-hidden which it probably shouldn't */
-[aria-hidden]:not(.line-highlight) {
-  display: none !important;
-}
-
 // No tooltips on mobile
 @media (max-width: 580px) {
   .hint--bottom {


### PR DESCRIPTION
aria-hidden (not area-hidden, as shown in the removed comment) is for accessibility purposes. 

Sometimes libraries add two associated elements, one for screen readers for disabled people and another one for the display. To avoid automatic detection of the redundant display item in screen readers, one can add aria-hidden to the display element. 

The removed lines of code were messing with many accessible libraries and should be removed.