### PR TITLE
[JSDoc] Link to the full list of keywords

### DIFF
--- a/jsdoc.md
+++ b/jsdoc.md
@@ -135,6 +135,8 @@ This syntax is [TypeScript-specific](https://github.com/Microsoft/TypeScript/wik
  */
 ```
 
+See the full list: <https://jsdoc.app/index.html#block-tags>
+
 ### Renaming
 
 ```js


### PR DESCRIPTION
It's probably too much to put in all keywords, but we can at least link to the official list.