### PR TITLE
bluebird: `Promise.prototype.finally` is standard Promise API method

### DIFF
--- a/bluebird.md
+++ b/bluebird.md
@@ -18,7 +18,7 @@ promise
   .spread(okFn, errFn)        // *
   .catch(errFn)
   .catch(TypeError, errFn)    // *
-  .finally(fn)                // *
+  .finally(fn)
   .map(function (e) { ··· })  // *
   .each(function (e) { ··· }) // *
 ```


### PR DESCRIPTION
Don't mark [`Promise.prototype.finally`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally) as non-standard/Bluebird extension.