### PR TITLE
Fix xpath.md

### DIFF
--- a/xpath.md
+++ b/xpath.md
@@ -401,7 +401,7 @@ count(//*)          # count all elements
 Finds a `<section>` that directly contains `h1#section-name`
 
 ```bash
-//section[//h1[@id='section-name']]
+//section[.//h1[@id='section-name']]
 ```
 
 Finds a `<section>` that contains `h1#section-name`.


### PR DESCRIPTION
```bash
//section[//h1[@id='section-name']]
```
Finds a `<section>` if `h1#section-name` is found anywhere (doesn't need to be a descendant of `<section>`).

<br />

```bash
//section[.//h1[@id='section-name']]
```
Finds a `<section>` that contains `h1#section-name`.