### PR TITLE
Adds info about text interpolation on the slim cheat sheet

### DIFF
--- a/slim.md
+++ b/slim.md
@@ -77,9 +77,18 @@ Depending on your parser, like [Kramdown](https://kramdown.gettalong.org/quickre
 
 ```jade
 javascript:
-  alert('Slim supports embedded javascript!')
+  alert('Slim supports embedded javascript!')  
 ```
 
+You can use text interpolation to access values from ruby on the javascript code.
+
+### Text interpolation
+
+```jade
+div Escaped #{content}
+div Unescaped #{{content}}
+div Not interpolated \#{content}
+```
 
 ### Comments
 


### PR DESCRIPTION
I've had a hard time figuring out how to output raw content on javascript, but it turns out you can just use normal text interpolation, I think this information is usefull on the cheat sheet.