### PR TITLE
emmet -  missing item

### DIFF
--- a/emmet.md
+++ b/emmet.md
@@ -94,7 +94,7 @@ ul.menu>li.menu__item+li#id_item+li.menu__item#id_2
 ```
 Expands to
 ```html
-<ul>
+<ul class="menu">
   <li class="menu__item"></li>
   <li id="id_item"></li>
   <li class="menu__item" id="id_2"></li>
@@ -130,6 +130,13 @@ Expands to
   <li class="item3"></li>
   <li class="item4"></li>
   <li class="item5"></li>
+</ul>
+<ul>
+  <li class="item3"></li>
+  <li class="item4"></li>
+  <li class="item5"></li>
+  <li class="item6"></li>
+  <li class="item7"></li>
 </ul>
 ```
 


### PR DESCRIPTION
Hello I noticed that the class for "IDs and Classes" was missing

in Numbering the last example is missing and I did not modify it but I do not get the same result for : ul>li.item$@-*3 

    <ul> 
	    <li class="item1@-"></li>
	    <li class="item2@-"></li>
	    <li class="item3@-"></li>
	</ul>
