### PR TITLE
gitpod: Make Gitpod's automated dev setup automatically run Jekyll and Parcel

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,15 @@
 image: gitpod/workspace-full
 
+ports:
+  - port: 4001
+    onOpen: open-preview
+
+tasks:
+  - init: yarn install && bundle install
+    command: env PORT=4001 yarn run dev
+
 github:
-  # Prebuild the docker image for gitpod - https://www.gitpod.io/docs/46_prebuilds/
+  # Prebuild the docker image for gitpod - https://www.gitpod.io/docs/prebuilds/
   prebuilds:
     # enable for the master/default branch
     master: true
-
-tasks:
-  - init: bundle install


### PR DESCRIPTION
Hi! 👋

I saw in `CONTRIBUTING.md` that one can start a preview server by running `yarn install`, `bundle install` and `env PORT=4001 yarn run dev`.

I've thus added these commands to the `tasks` in `.gitpod.yml`, so that Gitpod automatically runs them when you start a workspace for this repository.

You can test this Pull Request by opening my fork in Gitpod: https://gitpod.io/#https://github.com/jankeromnes/cheatsheets

This is what it looks like:

![Screenshot 2020-12-07 at 15 14 52](https://user-images.githubusercontent.com/599268/101361229-fcab3900-389e-11eb-828f-e93ec4a8217d.png)
