### PR TITLE
Tig - Fix view name for s key value

### DIFF
--- a/tig.md
+++ b/tig.md
@@ -72,7 +72,7 @@ You can substitute `git log` → `tig`.
 | `C` | Cherry pick a commit        |
 {: .-shortcuts}
 
-### `s` - Stage view
+### `s` - Status view
 
 | `u`     | Stage/unstage file or chunk        |
 | `!`     | Revert file or chunk               |


### PR DESCRIPTION
`s` key value stands for Status instead of Stage view.
Stage view can be accessed with `c` key value.

Reference: http://jonas.nitro.dk/tig/manual.html#view-switching