### PR TITLE
Updated description for arguments section

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -343,13 +343,16 @@ fi
 
 ### Arguments
 
-| Expression | Description                            |
-| ---        | ---                                    |
-| `$#`       | Number of arguments                    |
-| `$*`       | All arguments                          |
-| `$@`       | All arguments, starting from first     |
-| `$1`       | First argument                         |
-| `$_`       | Last argument of the previous command  |
+| Expression | Description                                      |
+| ---        | ---                                              |
+| `$#`       | Number of arguments                              |
+| `$*`       | All postional arguments  (as a single word)     |
+| `$@`       | All postitional arguments (as separate strings)  |
+| `$1`       | First argument                                   |
+| `$_`       | Last argument of the previous command            |
+
+**Note**: `$@` and `$*` must be quoted in order to perform as described.
+Otherwise, they do exactly the same thing (arguments as separate strings).
 
 See [Special parameters](http://wiki.bash-hackers.org/syntax/shellvars#special_parameters_and_shell_variables).
 


### PR DESCRIPTION
I think the description for the special parameters `$@` and `$*` was somehow incomplete and possibly misleading. The only difference  is that one of the description reads "starting from first", which I don't quite understand. It suggest somehow the other positional parameter starts in a different parameter? I believe that can be misleading, and it does not explain the essence of the parameters.