### PR TITLE
Add Map.from_struct and Kernel.struct to maps section of Elixir cheatsheet

### DIFF
--- a/elixir.md
+++ b/elixir.md
@@ -429,13 +429,15 @@ Map.new([a: 1, b: 2])
 Map.new([:a, :b], fn x -> {x, x} end)  # → %{a: :a, b: :b}
 ```
 
-### Constructing from structs
+### Working with structs
+
+#### Struct to map
 
 ```elixir
 Map.from_struct(%AnyStruct{a: "b"})  # → %{a: "b"}
 ```
 
-### Converting to a struct
+#### Map to struct
 
 ```elixir
 struct(AnyStruct, %{a: "b"})  # → %AnyStruct{a: "b"}

--- a/elixir.md
+++ b/elixir.md
@@ -429,6 +429,18 @@ Map.new([a: 1, b: 2])
 Map.new([:a, :b], fn x -> {x, x} end)  # → %{a: :a, b: :b}
 ```
 
+### Constructing from structs
+
+```elixir
+Map.from_struct(%AnyStruct{a: "b"})  # → %{a: "b"}
+```
+
+### Converting to a struct
+
+```elixir
+struct(AnyStruct, %{a: "b"})  # → %AnyStruct{a: "b"}
+```
+
 ## List
 
 ```elixir


### PR DESCRIPTION
Added Map.from_struct and Kernel.struct to maps section.