### PR TITLE
Fix a few examples that were using wrong CSS pseudo-classes

### DIFF
--- a/xpath.md
+++ b/xpath.md
@@ -61,12 +61,12 @@ Works in Firefox and Chrome.
 
 | CSS                          | Xpath                                                    | ?                       |
 | ----                         | ----                                                     | --                      |
-| `ul > li:first-child`        | `//ul/li[1]`                                             | [?](#indexing)          |
-| `ul > li:nth-child(2)`       | `//ul/li[2]`                                             |                         |
-| `ul > li:last-child`         | `//ul/li[last()]`                                        |                         |
-| `li#id:first-child`          | `//li[@id="id"][1]`                                      |                         |
-| `a:first-child`              | `//a[1]`                                                 |                         |
-| `a:last-child`               | `//a[last()]`                                            |                         |
+| `ul > li:first-of-type`      | `//ul/li[1]`                                             | [?](#indexing)          |
+| `ul > li:nth-of-type(2)`     | `//ul/li[2]`                                             |                         |
+| `ul > li:last-of-type`       | `//ul/li[last()]`                                        |                         |
+| `li#id:first-of-type`        | `//li[1][@id="id"]`                                      | [?](#chaining-order)    |
+| `a:first-child`              | `//*[1][name()="a"]`                                     |                         |
+| `a:last-child`               | `//*[last()][name()="a"]`                                |                         |
 {: .xp}
 
 ### Siblings
@@ -217,7 +217,7 @@ You can use nodes inside predicates.
 //a[last()]             # last <a>
 //ol/li[2]              # second <li>
 //ol/li[position()=2]   # same as above
-//ol/li[position()>1]   # :not(:first-child)
+//ol/li[position()>1]   # :not(:first-of-type)
 ```
 
 Use `[]` with a number, or `last()` or `position()`.


### PR DESCRIPTION
`[1]` is only equivalent to `:first-child` if all the children are of the same type. Using `:first-of-type` would be more accurate. I changed either CSS or XPath depending on which seemed to make the example more useful.