### PR TITLE
vimscript: Fix invalid code example

### DIFF
--- a/vimscript.md
+++ b/vimscript.md
@@ -140,7 +140,7 @@ function! s:Initialize(cmd, args)
   " a: prefix for arguments
   echo "Command: " . a:cmd
 
-  return true
+  return 1
 endfunction
 ```
 


### PR DESCRIPTION
Replace the line "return true" with "return 1". As the document explains
elsewhere, Vimscript does not have booleans.