### PR TITLE
Update atom.md

### DIFF
--- a/atom.md
+++ b/atom.md
@@ -70,8 +70,8 @@ See: [Symbols view](https://atom.io/packages/symbols-view)
 | `⌘d`     | Select word    |
 | `⌘l`     | Select line    |
 | ---      | ---            |
-| `⌘↓`     | Move line down |
-| `⌘↑`     | Move line up   |
+| `^⌘↓`     | Move line down |
+| `^⌘↑`     | Move line up   |
 | ---      | ---            |
 | `⌘⏎`     | New line below |
 | `⌘⇧⏎`    | New line above |


### PR DESCRIPTION
The default keybindings for move-line-down and move-line-up are ctrl-cmd-down and ctrl-cmd-up, respectively. ctrl added to these commands here.