### PR TITLE
Adds column names for transaction code and transaction notes. Fixes typo 'expneses'.

### DIFF
--- a/ledger-csv.md
+++ b/ledger-csv.md
@@ -13,10 +13,10 @@ $ ledger csv
 {: .-setup}
 
 ```csv
-date         , ?  , desc     , account            , currency , amt     , pending/cleared , ?
-"2013/09/02" , "" , "things" , "Assets:Cash"      , "P"      , "-2000" , "*"             , ""
-"2013/09/02" , "" , "things" , "Liabilities:Card" , "P"      , "-200"  , "*"             , ""
-"2013/09/02" , "" , "things" , "Expenses:Things"  , "P"      , "2200"  , "*"             , ""
-"2013/09/04" , "" , "stuff"  , "Assets:Cash"      , "P"      , "-20"   , "*"             , ""
-"2013/09/04" , "" , "stuff"  , "Expneses:Others"  , "P"      , "20"    , "*"             , ""
+date         , code  , desc     , account            , currency , amt     , pending/cleared , notes
+"2013/09/02" , ""    , "things" , "Assets:Cash"      , "P"      , "-2000" , "*"             , ""
+"2013/09/02" , ""    , "things" , "Liabilities:Card" , "P"      , "-200"  , "*"             , ""
+"2013/09/02" , ""    , "things" , "Expenses:Things"  , "P"      , "2200"  , "*"             , ""
+"2013/09/04" , ""    , "stuff"  , "Assets:Cash"      , "P"      , "-20"   , "*"             , ""
+"2013/09/04" , ""    , "stuff"  , "Expenses:Others"  , "P"      , "20"    , "*"             , ""
 ```


### PR DESCRIPTION
Transaction code is an arbitrary code assigned to a transaction (check number, invoice number...). It is specified between parentheses just before the transaction description.
Transaction notes are written as comments after a semicolon.

Example:
```
2021-10-30 * (ABC123) Stuff
    Expenses:Things        P 50.00    ; Something I need to remember about this transaction
    Assets:Cash
```