### PR TITLE
Correct the emphasis markup

### DIFF
--- a/org-mode.md
+++ b/org-mode.md
@@ -44,8 +44,8 @@ To buy:
 *bold*
 /italic/
 _underline_
-=code=
-~verbatim~
+=verbatim=
+~code~
 +strike-through+
 ```
 


### PR DESCRIPTION
According to https://orgmode.org/manual/Emphasis-and-Monospace.html,
it should be `=verbatim=` and `~code~`