### PR TITLE
Update bash.md

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -649,6 +649,7 @@ python hello.py &>/dev/null    # stdout and stderr to (null)
 
 ```bash
 python hello.py < foo.txt      # feed foo.txt to stdin for python
+diff <(ls -r) <(ls)            # Compare two stdout without files
 ```
 
 ### Inspecting commands


### PR DESCRIPTION
This is an example how Bash can re-direct two stdout stream to two file descriptors and use that for commands that only accept file names and no stdin.