### PR TITLE
Remove bad negative example from capybara sheet

### DIFF
--- a/capybara.md
+++ b/capybara.md
@@ -122,11 +122,11 @@ In RSpec, you can use `page.should` assertions.
 expect(page).to have_no_button('Save')   # OK
 ```
 ```ruby
-expect(page).not_to have_button('Save')  # Bad
+expect(page).not_to have_button('Save')  # OK
 ```
-
-Use `should have_no_*` versions with RSpec matchers because
-`should_not have_*` doesn't wait for a timeout from the driver.
+```ruby
+!expect(page).to have_button('Save')  # Bad
+```
 
 ## RSpec
 


### PR DESCRIPTION
Removes the bad negative example and adds a new one that still has bad performance.

 It use to be that `not_to` would wait
in a non-performant way:
https://www.cloudbees.com/blog/faster-rails-tests 


but now it it no longer waits: 
https://github.com/rubocop/rubocop-rspec/issues/378#issuecomment-463250177