### PR TITLE
Add wildcard examples to bash conditions

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -364,23 +364,26 @@ Conditionals
 
 Note that `[[` is actually a command/program that returns either `0` (true) or `1` (false). Any program that obeys the same logic (like all base utils, such as `grep(1)` or `ping(1)`) can be used as condition, see examples.
 
-| Condition                | Description           |
-| ---                      | ---                   |
-| `[[ -z STRING ]]`        | Empty string          |
-| `[[ -n STRING ]]`        | Not empty string      |
-| `[[ STRING == STRING ]]` | Equal                 |
-| `[[ STRING != STRING ]]` | Not Equal             |
-| ---                      | ---                   |
-| `[[ NUM -eq NUM ]]`      | Equal                 |
-| `[[ NUM -ne NUM ]]`      | Not equal             |
-| `[[ NUM -lt NUM ]]`      | Less than             |
-| `[[ NUM -le NUM ]]`      | Less than or equal    |
-| `[[ NUM -gt NUM ]]`      | Greater than          |
-| `[[ NUM -ge NUM ]]`      | Greater than or equal |
-| ---                      | ---                   |
-| `[[ STRING =~ STRING ]]` | Regexp                |
-| ---                      | ---                   |
-| `(( NUM < NUM ))`        | Numeric conditions    |
+| Condition                  | Description           |
+| ---                        | ---                   |
+| `[[ -z STRING ]]`          | Empty string          |
+| `[[ -n STRING ]]`          | Not empty string      |
+| `[[ STRING == STRING ]]`   | Equal                 |
+| `[[ STRING != STRING ]]`   | Not Equal             |
+| ---                        | ---                   |
+| `[[ NUM -eq NUM ]]`        | Equal                 |
+| `[[ NUM -ne NUM ]]`        | Not equal             |
+| `[[ NUM -lt NUM ]]`        | Less than             |
+| `[[ NUM -le NUM ]]`        | Less than or equal    |
+| `[[ NUM -gt NUM ]]`        | Greater than          |
+| `[[ NUM -ge NUM ]]`        | Greater than or equal |
+| ---                        | ---                   |
+| `[[ STRING =~ STRING ]]`   | Regexp                |
+| `[[ STRING == *STRING* ]]` | Wildcards (substring) |
+| `[[ STRING == STRING* ]]`  | Wildcard (starts with)|
+| `[[ STRING == *STRING ]]`  | Wildcard (ends with)  |
+| ---                        | ---                   |
+| `(( NUM < NUM ))`          | Numeric conditions    |
 
 #### More conditions
 


### PR DESCRIPTION
Add examples for checking whether a string contains another string or starts or ends with another string using wildcards.