### PR TITLE
Fixed bug in WaitGroup example

### DIFF
--- a/go.md
+++ b/go.md
@@ -431,7 +431,7 @@ func main() {
   for _, item := range itemList {
     // Increment WaitGroup Counter
     wg.Add(1)
-    go doOperation(item)
+    go doOperation(&wg, item)
   }
   // Wait for goroutines to finish
   wg.Wait()
@@ -441,7 +441,7 @@ func main() {
 {: data-line="1,4,8,12"}
 
 ```go
-func doOperation(item string) {
+func doOperation(wg *sync.WaitGroup, item string) {
   defer wg.Done()
   // do operation on item
   // ...


### PR DESCRIPTION
The waitgroup that is defined in main() with var wg sync.WaitGroup, only has scope inside the main() function. The doOperation() function will not know about it and so the defer wg.Done() line will result in a compile time error. The waitgroup needs to be passed as a parameter to the doOperation() function.