### PR TITLE
Add @async to JSDoc `Other keywords` section

### DIFF
--- a/jsdoc.md
+++ b/jsdoc.md
@@ -128,6 +128,7 @@ This syntax is [TypeScript-specific](https://github.com/Microsoft/TypeScript/wik
 ```js
 /**
  * @throws {FooException}
+ * @async
  * @private
  * @deprecated
  * @see


### PR DESCRIPTION
Async is so prevalent these days, felt like it was important to include in a cheatsheet.