### PR TITLE
mako: fix front-matter

### DIFF
--- a/mako.md
+++ b/mako.md
@@ -1,6 +1,6 @@
 ---
-title: mako
-category: python
+title: Mako
+category: Python
 layout: 2017/sheet
 ---
 


### PR DESCRIPTION
The whole page is hidden from the index due to typo