### PR TITLE
[Xpath] Add an example of selection of all leaf elements

### DIFF
--- a/xpath.md
+++ b/xpath.md
@@ -391,6 +391,7 @@ count(//*)          # count all elements
 //li[span]          # find a <li> with an <span> inside it
                     # ...expands to //li[child::span]
 //ul/li/..          # use .. to select a parent
+//*[not(*)]         # any element that doesn't have a child element
 ```
 
 ### Find a parent
@@ -428,3 +429,4 @@ References
 {: .-one-column}
 
 * [Xpath test bed](http://www.whitebeam.org/library/guide/TechNotes/xpathtestbed.rhtm) _(whitebeam.org)_
+* [How to select all leaf nodes](https://stackoverflow.com/a/3926682/747872) _(stackoverflow.com)_


### PR DESCRIPTION
This PR adds an example of Xpath expression to select leaf elements (elements without a child element).

## Credits

The solution was posted by Dimitre Novatchev on [Stackoverflow](https://stackoverflow.com/a/3926682/747872).