### PR TITLE
alternate cmd for insert data in sql

### DIFF
--- a/mysql.md
+++ b/mysql.md
@@ -87,6 +87,7 @@ mysqlcheck --all-databases --fast;
 
 ```sql
 INSERT INTO table1 (field1, field2) VALUES (value1, value2);
+INSERT INTO table1 VALUES (value1, value2);
 ```
 
 ### Delete


### PR DESCRIPTION
added an alternate command for inserting data in mySQL
which is handy and easy to write.

```sql
INSERT INTO table1 VALUES (value1, value2);
```