### PR TITLE
fix: make the meaning of ^ and $ more precise

### DIFF
--- a/regexp.md
+++ b/regexp.md
@@ -35,18 +35,20 @@ description: |
 
 ### Anchors
 
-| Pattern | Description                                             |
-| ------- | ------------------------------------------------------- |
-| `\G`    | Start of match                                          |
-| `^`     | Start of string, or start of line in multi-line pattern |
-| `$`     | End of string, or end of line in multi-line pattern     |
-| `\A`    | Start of string                                         |
-| `\Z`    | End of string                                           |
-| `\z`    | Absolute end of string                                  |
-| `\b`    | A word boundry                                          |
-| `\B`    | Non-word boundry                                        |
-| `^abc`  | Start with `abc`                                        |
-| `abc$`  | End with `abc`                                          |
+| Pattern | Description            |
+| ------- | ---------------------- |
+| `\G`    | Start of match         |
+| `^`     | Start of string \*     |
+| `$`     | End of string \*       |
+| `\A`    | Start of string        |
+| `\Z`    | End of string          |
+| `\z`    | Absolute end of string |
+| `\b`    | A word boundry         |
+| `\B`    | Non-word boundry       |
+| `^abc`  | Start with `abc`       |
+| `abc$`  | End with `abc`         |
+
+For multiline patterns (`m` flag), `^` and `$` will act as start and end of line.
 
 ### Escaped characters
 

--- a/regexp.md
+++ b/regexp.md
@@ -35,18 +35,18 @@ description: |
 
 ### Anchors
 
-| Pattern | Description             |
-| ------- | ----------------------- |
-| `\G`    | Start of match          |
-| `^`     | Start of string         |
-| `$`     | End of string           |
-| `\A`    | Start of string         |
-| `\Z`    | End of string           |
-| `\z`    | Absolute end of string  |
-| `\b`    | A word boundry          |
-| `\B`    | Non-word boundry        |
-| `^abc`  | Start with `abc`        |
-| `abc$`  | End with `abc`          |
+| Pattern | Description                                             |
+| ------- | ------------------------------------------------------- |
+| `\G`    | Start of match                                          |
+| `^`     | Start of string, or start of line in multi-line pattern |
+| `$`     | End of string, or end of line in multi-line pattern     |
+| `\A`    | Start of string                                         |
+| `\Z`    | End of string                                           |
+| `\z`    | Absolute end of string                                  |
+| `\b`    | A word boundry                                          |
+| `\B`    | Non-word boundry                                        |
+| `^abc`  | Start with `abc`                                        |
+| `abc$`  | End with `abc`                                          |
 
 ### Escaped characters
 


### PR DESCRIPTION
^ and $ work differently in multi-line pattern which are different from \A and \Z.