### PR TITLE
tig: Fix traling newline in header

### DIFF
--- a/tig.md
+++ b/tig.md
@@ -103,6 +103,7 @@ You can substitute `git log` → `tig`.
 {: .-shortcuts}
 
 ### `s` - Status view
+
 | Shortcut  | Description                        |
 | ---       | ---                                |
 | `u`       | Stage/unstage file or chunk        |


### PR DESCRIPTION
There is no newline between the header and the table body, resulting in a rendering issue at https://devhints.io/tig.

This PR adds a newline after the section header.