### PR TITLE
Removed :q! and :qa!

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -19,14 +19,11 @@ Getting started
 
 | Shortcut       | Description                      |
 | -------------- | -------------------------------- |
+| `:q`           | Close file                       |
 | `:qa`          | Close all files                  |
-| `:qa!`         | Close all files, abandon changes |
 | ---            | ---                              |
 | `:w`           | Save                             |
 | `:wq` _/_ `:x` | Save and close file              |
-| ---            | ---                              |
-| `:q`           | Close file                       |
-| `:q!`          | Close file, abandon changes      |
 | ---            | ---                              |
 | `ZZ`           | Save and quit                    |
 | `ZQ`           | Quit without checking changes    |


### PR DESCRIPTION
A short cheat sheet is more efficient and user-friendly than a bloated manual, as it presents only the most essential information in a clear and concise format. Furthermore, having a compact cheat sheet allows for easy accessibility and quick reference, making it more likely to be used and retained in a time-sensitive or high-pressure situation.

This is why I propose to remove some of the commands to improve readability.

When typing `:q` in vim with unsaved changes, vim refuses to quit and suggests to use `:q!`. This is why I propose to remove this and the `:qa!` equivalent from the cheat sheet. The information is not needed here because when u need it, vim already suggests it to you.