### PR TITLE
Add Command Line Interface Pages (CLIP) page syntax examples

### DIFF
--- a/clip.md
+++ b/clip.md
@@ -1,0 +1,45 @@
+---
+title: Command Line Interface Pages
+category: CLI
+layout: 2023/sheet
+tags: [Featured]
+updated: 2023-02-23
+keywords:
+  - CLI
+---
+
+### Page layout
+
+```md
+# command
+
+> Some command description
+> More information: https://some/link/to/url
+
+- Some code description:
+
+`command argument1 argument2`
+```
+
+### [Primitive placeholders](https://github.com/emilyseville7cfg-better-tldr/syntax/blob/main/syntax.md#page-examples)
+
+```md
+- Delay in [s]econds:
+
+`sleep {int seconds: 2}s`
+```
+
+### [Primitive repeated placeholders](https://github.com/emilyseville7cfg-better-tldr/syntax/blob/main/syntax.md#page-examples)
+
+```md
+- [c]reate an archive and write it to a [f]ile:
+
+`tar {option mode: --create, -c} {option: --file, -f} {/?file archive: target.tar} {/?path+ input}`
+```
+
+### Also see
+{: .-one-column}
+
+* [Render](https://github.com/emilyseville7cfg-better-tldr/prototypes/tree/main/clip-view)
+* [Page's repository](https://github.com/emilyseville7cfg-better-tldr/cli-pages)
+* [Syntax](https://github.com/emilyseville7cfg-better-tldr/syntax/blob/main/syntax.md)

--- a/clip.md
+++ b/clip.md
@@ -1,7 +1,7 @@
 ---
 title: Command Line Interface Pages
 category: CLI
-layout: 2023/sheet
+layout: 2017/sheet
 tags: [Featured]
 updated: 2023-02-23
 keywords:
@@ -21,7 +21,7 @@ keywords:
 `command argument1 argument2`
 ```
 
-### [Primitive placeholders](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md#page-examples)
+### [Primitive placeholders](https://github.com/command-line-interface-pages/syntax/blob/main/type-specific/cli.md#primitive-placeholders)
 
 ```md
 - Delay in [s]econds:
@@ -29,7 +29,7 @@ keywords:
 `sleep {int seconds: 2}s`
 ```
 
-### [Primitive repeated placeholders](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md#page-examples)
+### [Primitive repeated placeholders](https://github.com/command-line-interface-pages/syntax/blob/main/type-specific/cli.md#repeated-primitive-placeholders)
 
 ```md
 - [c]reate an archive and write it to a [f]ile:
@@ -40,6 +40,6 @@ keywords:
 ### Also see
 {: .-one-column}
 
-* [Render](https://github.com/command-line-interface-pages/prototypes/tree/main/clip-view)
+* [Render](https://github.com/command-line-interface-pages/v2-tooling/tree/main/clip-view)
 * [Page's repository](https://github.com/command-line-interface-pages/cli-pages)
-* [Syntax](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md)
+* [Syntax](https://github.com/command-line-interface-pages/syntax/blob/main/base.md)

--- a/clip.md
+++ b/clip.md
@@ -21,7 +21,7 @@ keywords:
 `command argument1 argument2`
 ```
 
-### [Primitive placeholders](https://github.com/emilyseville7cfg-better-tldr/syntax/blob/main/syntax.md#page-examples)
+### [Primitive placeholders](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md#page-examples)
 
 ```md
 - Delay in [s]econds:
@@ -29,7 +29,7 @@ keywords:
 `sleep {int seconds: 2}s`
 ```
 
-### [Primitive repeated placeholders](https://github.com/emilyseville7cfg-better-tldr/syntax/blob/main/syntax.md#page-examples)
+### [Primitive repeated placeholders](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md#page-examples)
 
 ```md
 - [c]reate an archive and write it to a [f]ile:
@@ -40,6 +40,6 @@ keywords:
 ### Also see
 {: .-one-column}
 
-* [Render](https://github.com/emilyseville7cfg-better-tldr/prototypes/tree/main/clip-view)
-* [Page's repository](https://github.com/emilyseville7cfg-better-tldr/cli-pages)
-* [Syntax](https://github.com/emilyseville7cfg-better-tldr/syntax/blob/main/syntax.md)
+* [Render](https://github.com/command-line-interface-pages/prototypes/tree/main/clip-view)
+* [Page's repository](https://github.com/command-line-interface-pages/cli-pages)
+* [Syntax](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md)


### PR DESCRIPTION
## Notes

Other [CLIP](https://github.com/command-line-interface-pages/prototypes/tree/main/clip-view) project tools will be added later. Accepting this PR will help my project gain more popularity, thanks for understanding. 

![image](https://user-images.githubusercontent.com/42812113/217810573-6f8407e0-7287-4ebd-9350-d0e5d88d0ebf.png)

## Important

This project goal is to replace [TlDr](https://github.com/tldr-pages/tldr) project completely. CLIP project already has better client in terms of feature amount compared to [TlDr official one](https://github.com/tldr-pages/tldr-python-client) and third party clients. To be specific: it [provides](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md) more expressive and clear syntax for writing pages, [color theme](https://github.com/command-line-interface-pages/prototypes/pull/22) support. Even TlDr maintainers help me to develop it I think their main goal is to make TlDr project better and not mine, so I expect the most of the help from non-TlDr contributors.