### PR TITLE
fix typo in tar.md

### DIFF
--- a/tar.md
+++ b/tar.md
@@ -36,11 +36,11 @@ tar -zu archive.tar.gz -C /target/file
 
 ### Common options
 
-| Option | Description                                                              |
-|--------|--------------------------------------------------------------------------|
-| `z`    | compress with gzip                                                       |
-| `c`    | create an archive                                                        |
+| Option | Description                                                             |
+|--------|-------------------------------------------------------------------------|
+| `z`    | compress with gzip                                                      |
+| `c`    | create an archive                                                       |
 | `u`    | append files which are newer than the corresponding copy in the archive |
-| `f`    | filename of the archive                                                  |
-| `v`    | verbose, display what is inflated or deflated                            |
-| `a`    | unlike of `z`, determine compression based on file extension             |
+| `f`    | filename of the archive                                                 |
+| `v`    | verbose, display what is inflated or deflated                           |
+| `a`    | unlike of `z`, determine compression based on file extension            |

--- a/tar.md
+++ b/tar.md
@@ -40,7 +40,7 @@ tar -zu archive.tar.gz -C /target/file
 |--------|--------------------------------------------------------------------------|
 | `z`    | compress with gzip                                                       |
 | `c`    | create an archive                                                        |
-| `u`    | append files which are newer than the corresponding copy ibn the archive |
+| `u`    | append files which are newer than the corresponding copy in the archive |
 | `f`    | filename of the archive                                                  |
 | `v`    | verbose, display what is inflated or deflated                            |
 | `a`    | unlike of `z`, determine compression based on file extension             |


### PR DESCRIPTION
Just a very little typo fix in the `tar.md` document