### PR TITLE
Fix before/after with no arg

### DIFF
--- a/rspec.md
+++ b/rspec.md
@@ -49,11 +49,11 @@ before :each do
   # before all tests
 end
 
-before do
+before :all do
   # before this suite
 end
 
-after do
+after : all do
   # after this suite
 end
 ```


### PR DESCRIPTION
No arg defaults to :each not :all 

https://www.rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FHooks:before