### PR TITLE
Add add symbol for length of array

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -220,9 +220,9 @@ comment
 
 ### Length
 
-| Expression | Description      |
-| ---------- | ---------------- |
-| `${#foo}`  | Length of `$foo` |
+| Expression    | Description      |
+| ------------- | ---------------- |
+| `${#foo[@]}`  | Length of `$foo` |
 
 ### Manipulation
 


### PR DESCRIPTION
Using the length operator as is on empty array with `set -u` will lead to unbound variable error