### PR TITLE
Remove redundant syntax

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -335,7 +335,7 @@ myfunc() {
 
 ```bash
 # Same as above (alternate syntax)
-function myfunc() {
+function myfunc {
     echo "hello $1"
 }
 ```


### PR DESCRIPTION
Either use the `function` or `()` but not both, it's redundant.