### PR TITLE
Two changes : Correction on Fish cheatsheet & version update on Docker compose 

### DIFF
--- a/docker-compose.md
+++ b/docker-compose.md
@@ -4,7 +4,7 @@ category: Devops
 layout: 2017/sheet
 prism_languages: [yaml]
 weight: -1
-updated: 2020-01-01
+updated: 2024-04-03 
 ---
 
 ### Basic example
@@ -27,22 +27,54 @@ services:
     image: redis
 ```
 
+
+### Version 1 to 2
+
+Docker compose is now integrated into the official Docker installation. The functionality only improved over that change, and the simple syntax change is : V1 : `docker-compose ARG` to V2 `docker compose ARG`
+More on that here : [Docker Compose](https://docs.docker.com/compose/) [Migrate to V2](https://docs.docker.com/compose/migrate/)
+
 ### Commands
 
+
 ```sh
-docker-compose start
-docker-compose stop
+docker compose version 
+docker compose config    
 ```
 
 ```sh
-docker-compose pause
-docker-compose unpause
+docker compose start
+docker compose stop
+docker compose restart
+docker compose run    
 ```
 
 ```sh
-docker-compose ps
-docker-compose up
-docker-compose down
+docker compose create  
+docker compose attach      
+docker compose pause
+docker compose unpause
+```
+
+```sh
+docker compose wait   
+docker compose up
+docker compose down
+```
+
+```sh 
+docker compose ps
+docker compose top 
+docker compose events   
+docker compose logs
+```
+
+
+```sh
+docker compose images
+docker compose build      
+docker compose push  
+docker compose cp       
+docker compose exec 
 ```
 
 ## Reference

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 services:
   web:
     build: .

--- a/fish-shell.md
+++ b/fish-shell.md
@@ -177,7 +177,7 @@ end
 
 | String operator     | Meaning                                   |
 | ---                 | ---                                       |
-| `==`                | [Eq]ual                                   |
+| `=`                 | [Eq]ual                                   |
 | `!=`                | [N]ot [E]qual                             |
 
 #### Files


### PR DESCRIPTION
## For the Fish cheatsheet : 
I was using this cheatsheet to brush back on fish conditionals. 

Turns out when you use something like 

```fish
test $TMUX_PROGRAM == '/usr/bin/tmux'
```

An error is returned : 
`test: unexpected argument at index 2: '=='`

```fish
test $TMUX_PROGRAM = '/usr/bin/tmux'
```
Works fine. 

The official documentation uses the same operator https://fishshell.com/docs/current/cmds/test.html


## For the Docker compose cheatsheet : 

I changed the documentation to follow the newer docker compose out of the box and summarized the migration for everyone.

The official documentation : 
https://docs.docker.com/compose/
https://docs.docker.com/compose/migrate/

I also took the opportunity to remind a few others useful docker compose commands, just in case they didn't exist back in last update in 2020. 