### PR TITLE
Remove a case that is not negative examples in the capybara sheet

### DIFF
--- a/capybara.md
+++ b/capybara.md
@@ -119,14 +119,14 @@ In RSpec, you can use `page.should` assertions.
 ### About negatives
 
 ```ruby
-expect(page).to have_no_button('Save')   # OK
+expect(page).to have_no_button('Save')
 ```
+
 ```ruby
-expect(page).not_to have_button('Save')  # OK
+expect(page).not_to have_button('Save')
 ```
-```ruby
-!expect(page).to have_button('Save')  # Bad
-```
+
+The two above statements are functionally equivalent.
 
 ## RSpec
 


### PR DESCRIPTION
```ruby
!expect(page).to have_button('Save')
```

The above case is a new Bad case added by https://github.com/rstacruz/cheatsheets/pull/1798 . It is designated as Bad due to performance issues, but it is not actually a Negative example. In practice, the following would be the same test:

```ruby
expect(page).to have_button('Save')
!expect(page).to have_button('Save')
```

This is not an example that will appear on the capybara cheat sheet, because it is a problem with how RSpec is written. I think it should be removed because it creates confusion.