### PR TITLE
New shortcut for vim.md

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -27,7 +27,7 @@ weight: -10
 | `:wq` _/_ `:x` | Save and close file              |
 | ---            | ---                              |
 | `ZZ`           | Save and quit                    |
-| `ZQ`           | Quit without checking changes    |
+| `:q!` _/_ `ZQ`           | Quit without checking changes    |
 {: .-shortcuts}
 
 ### Exiting insert mode


### PR DESCRIPTION
New shortcut `:q!` added for quit without checking changes in `vim.md` file.