### PR TITLE
Include warning on polyfill.io sheet; use CF instead

### DIFF
--- a/polyfill.io.md
+++ b/polyfill.io.md
@@ -6,11 +6,11 @@ intro: |
   Polyfill.io is a service that serves JavaScript polyfills.
 ---
 
-> ⚠️ **CRITICAL SECURITY WARNING**
->
-> The polyfill.io CDN domain is currently being used in a web supply chain attack and is serving malicious code. **Remove any references to this domain from your codebase immediately**. Use alternative CDN providers like cdnjs.cloudflare.com as shown in the examples below.
-
 ## Usage
+
+### Critical security warning
+
+⚠️ The polyfill.io CDN domain is currently being used in a web supply chain attack and is serving malicious code. **Remove any references to this domain from your codebase immediately**. Use alternative CDN providers like cdnjs.cloudflare.com as shown in the examples below.
 
 ### Default usage
 

--- a/polyfill.io.md
+++ b/polyfill.io.md
@@ -1,33 +1,37 @@
 ---
 title: Polyfill.io
 category: JavaScript libraries
-updated: 2018-08-20
+updated: 2024-06-26
 intro: |
-  [Polyfill.io](https://polyfill.io) is a service that serves JavaScript polyfills.
+  Polyfill.io is a service that serves JavaScript polyfills.
 ---
+
+> ⚠️ **CRITICAL SECURITY WARNING**
+>
+> The polyfill.io CDN domain is currently being used in a web supply chain attack and is serving malicious code. **Remove any references to this domain from your codebase immediately**. Use alternative CDN providers like cdnjs.cloudflare.com as shown in the examples below.
 
 ## Usage
 
 ### Default usage
 
 ```html
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
 ```
+
 {: .-wrap}
 
 This is the default script for Polyfill.io.
 
 ### References
 
-* [API example](https://polyfill.io/v2/docs/api) _(polyfill.io)_
-* [List of features](https://polyfill.io/v2/docs/features) _(polyfill.io)_
+* [Cloudflare now serves polyfill.io](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk) _(blog.cloudflare.com)_
 
 ## Optimized
 
 ### For modern browsers
 
 ```html
-<script>if(!(window.Promise&&[].includes&&Object.assign&&window.Map)){document.write('<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></scr'+'ipt>')}</script>
+<script>if(!(window.Promise&&[].includes&&Object.assign&&window.Map)){document.write('<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></scr'+'ipt>')}</script>
 ```
 
 This only includes polyfill.io when necessary, skipping it for modern browsers for faster load times.
@@ -35,7 +39,7 @@ This only includes polyfill.io when necessary, skipping it for modern browsers f
 ### Extra features
 
 ```html
-<script>if(!(window.fetch&&window.Promise&&[].includes&&Object.assign&&window.Map)){document.write('<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,fetch"></scr'+'ipt>')}</script>
+<script>if(!(window.fetch&&window.Promise&&[].includes&&Object.assign&&window.Map)){document.write('<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default,fetch"></scr'+'ipt>')}</script>
 ```
 
 This is the same as the previous, but also adds a polyfill for `window.fetch()`. We add a `window.fetch` check and loads the additional `fetch` feature.


### PR DESCRIPTION
A warning is added to the polyfill.io sheet in relation to the malicious script that is now being served by polyfill.io. Removed all links to that domain.

The code snippets have also been updated to use Cloudflare's script instead. This allows users to keep using polyfill securely while they move their codebase away from using this polyfill.

Cloudflare press release: https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk

Fixes #2145 