### PR TITLE
fix: annoying browser suggestions

### DIFF
--- a/src/components/V2017Sheet/SearchForm.astro
+++ b/src/components/V2017Sheet/SearchForm.astro
@@ -34,6 +34,7 @@ placeholder = placeholder.replace('{size}', etc.advertisedSheetCount.toString())
           {...(props.isLive ? { autofocus: true } : {})}
           data-js-search-input
           placeholder={placeholder}
+          autocomplete="off"
         />
       )
     }


### PR DESCRIPTION
I was looking for notes and then when i was searching svelte i couldn't see the possible search hits.so i turned autocomplete off now it works like charm.  