### PR TITLE
Embedded Images in Markdown

### DIFF
--- a/markdown.md
+++ b/markdown.md
@@ -106,6 +106,11 @@ ___bold italic___
 [img]: http://foo.com/img.jpg
 ```
 
+```markdown
+![Image alt text][img_base64]
+[img_base64]: <data:image/png;base64,...>
+```
+
 ### Code
 
 ```markdown


### PR DESCRIPTION
[GFM](https://loilo.github.io/gfm-preview/) now supports the ability to embed Base64 encoded images in Markdown.