### PR TITLE
Add Set Theory section to vim-digraphs cheatsheet

### DIFF
--- a/vim-digraphs.md
+++ b/vim-digraphs.md
@@ -51,11 +51,17 @@ category: Vim
 | √         | ×          | ÷           |
 | RT *root* | /\ *times* | -: *divide* |
 
-| ⊂           | ⊃             | ∩                 | ∪          |
-| (C *subset* | )C *superset* | (U *intersection* | )U *union* |
 
 | ¼  | ½  | ¾  | ₃  | ₂  | ³  | ²  |
 | 14 | 12 | 34 | 3s | 2s | 3S | 2S |
+
+### Set Theory
+
+| ∀         | ∃          | ∈              | ∅             | ⊆                    | ⊇                     |
+| FA *forall* | TE *exists* | (- *element of* | /0 *empty set* | (_ *subset or equal* | )_ *superset or equal* |
+
+| ∩                 | ∪          | ⊂           | ⊃             |
+| (U *intersection* | )U *union* | (C *subset* | )C *superset* |
 
 ### Greek
 


### PR DESCRIPTION
## Summary
- Added a new Set Theory section to the vim-digraphs cheatsheet
- Includes commonly used mathematical symbols for set theory operations
- Follows the existing format and style of the cheatsheet

## Changes
- Added Set Theory section with symbols for:
  - ∀ (forall) - `FA`
  - ∃ (exists) - `TE`
  - ∈ (element of) - `(-`
  - ∅ (empty set) - `/0`
  - ⊆ (subset or equal) - `(_`
  - ⊇ (superset or equal) - `)_`
  - ∩ (intersection) - `(U`
  - ∪ (union) - `)U`
  - ⊂ (subset) - `(C`
  - ⊃ (superset) - `)C`
- Removed duplicate set theory symbols from Math section
- Added descriptive labels for each symbol

## Test plan
- [x] Verified all digraph codes work in Vim
- [x] Checked formatting consistency with existing sections
- [x] Ensured no duplicate symbols across sections

🤖 Generated with [Claude Code](https://claude.ai/code)