### PR TITLE
Update variable declaration syntax in go.md

### DIFF
--- a/go.md
+++ b/go.md
@@ -55,7 +55,7 @@ var msg string = "Hello, world!"
 var x, y int
 var x, y int = 1, 2
 var x, msg = 1, "Hello, world!"
-msg = "Hello"
+msg := "Hello"
 ```
 
 #### Declaration list


### PR DESCRIPTION
Changed `Assignment` operator to `Declaration + Assignment` operator when `var` is not used.