### PR TITLE
Delete variable assignment from variable declarations section in Go

### DIFF
--- a/go.md
+++ b/go.md
@@ -55,7 +55,6 @@ var msg string = "Hello, world!"
 var x, y int
 var x, y int = 1, 2
 var x, msg = 1, "Hello, world!"
-msg = "Hello"
 ```
 
 #### Declaration list


### PR DESCRIPTION
Admittedly, I'm at a junior dev level, but I believe the code as written is syntactically incorrect. I think that the `:` is required for `msg` to be declared as a variable.  I don't believe you can just use the assignment operator (`=`) to declare `msg` as a variable by assigning it the value of `"Hello"` in the 'Go!' language like you can in python, dart, et al.

Go! does have type inference but it must be done with the walrus operator (`:=`).  Line 49 denotes that this is the `Variable Declaration` section so I believe the `:` preceding the `=` is necessary.

On deeper checking, I think this line should be deleted because it's syntactically incorrect and the shortcut for variable declaration and assignment using the walrus operator is already covered below.