### PR TITLE
Update clipboard commands in vim.md - Typo fix

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -75,7 +75,7 @@ weight: -10
 | `P`             | Paste before                |
 | ---             | ---                         |
 | `"*p` _/_ `"+p` | Paste from system clipboard |
-| `"*y` _/_ `"+y` | Paste to system clipboard   |
+| `"*y` _/_ `"+y` | Copy to system clipboard    |
 {: .-shortcuts}
 
 ### Visual mode


### PR DESCRIPTION
Keys `"*y` _/_ `"+y` should be described as `Copy to system clipboard` and not `Paste to system clipboard`