### PR TITLE
Remove potentially dangerous flag from the pacman uninstall command

### DIFF
--- a/pacman.md
+++ b/pacman.md
@@ -20,7 +20,7 @@ Pacman is the package manager for Arch Linux and its derivatives.
 | ----------------------- | --------------------------------- |
 | `pacman -Syu <pkg>`     | Install (and update package list) |
 | `pacman -S <pkg>`       | Install only                      |
-| `pacman -Rsc <pkg>`     | Uninstall                         |
+| `pacman -Rs <pkg>`      | Uninstall                         |
 | `pacman -Ss <keywords>` | Search                            |
 | `pacman -Syu`           | Upgrade everything                |
 {: .-prime}


### PR DESCRIPTION
Removed potentially dangerous recursive flag (`-c`) from the uninstall command.

The `-c` (cascade) flag removes all packages that depend on the target, which can recursively remove many potentially needed packages. This is dangerous to recommend on a cheat-sheet where users may run commands without reading man pages, and could cause people to brick their systems.

ArchWiki warns about this on the [Pacman page](https://wiki.archlinux.org/title/Pacman):
>Warning: This operation is recursive, and must be used with care since it can remove many potentially needed packages."